### PR TITLE
Propagate logout to API key

### DIFF
--- a/dev-portal/src/components/QspBreadcrumb/index.js
+++ b/dev-portal/src/components/QspBreadcrumb/index.js
@@ -16,11 +16,11 @@
 
 import React, { PureComponent } from 'react'
 import { Breadcrumb } from 'semantic-ui-react'
-import { Link, Redirect} from 'react-router-dom'
-import { logout, showApiKey, isAuthenticated } from '../../services/self'
+import { Link} from 'react-router-dom'
+import { isAuthenticated } from '../../services/self'
 import { getApi } from '../../services/api-catalog'
 
-export default class Head extends PureComponent {
+export default class QspBreadcrumb extends PureComponent {
   constructor(props) {
     super(props);
 
@@ -35,7 +35,6 @@ export default class Head extends PureComponent {
 
     this.state = {
       isAuthenticated: isAuthenticated(),
-      apiKey: ''
     }
   }
 
@@ -59,19 +58,8 @@ export default class Head extends PureComponent {
     return this.props.pattern === '/apis/:apiId'
   }
 
-  logout() {
-    logout();
-    this.setState({ loggedOut: true })
-  }
-
-  showApiKey() {
-    showApiKey().then(apiKey => {
-      this.setState({ apiKey })
-    })
-  }
-
   render() {
-    return this.state.loggedOut ? <Redirect to='/' /> : (<section style={{marginBottom: '1rem'}}>
+    return (<section style={{marginBottom: '1rem'}}>
       <Breadcrumb>
         { this.isHomeRoute() ? <Breadcrumb.Section active>Home</Breadcrumb.Section> : <Breadcrumb.Section><Link to="/">Home</Link></Breadcrumb.Section> }
         { this.isGettingStartedRoute() ? <Breadcrumb.Section active><Breadcrumb.Divider icon='right chevron' />Getting Started</Breadcrumb.Section> : ''}
@@ -79,14 +67,6 @@ export default class Head extends PureComponent {
         { this.isApisListRoute() ? <Breadcrumb.Section active><Breadcrumb.Divider icon='right chevron' />APIs</Breadcrumb.Section> : ''}
         { this.isApiDetailsRoute() ? <Breadcrumb.Section><Breadcrumb.Section><Breadcrumb.Divider icon='right chevron' /><Link to="/apis">APIs</Link></Breadcrumb.Section><Breadcrumb.Section active><Breadcrumb.Divider icon='right chevron' />{ this.state.apiName }</Breadcrumb.Section></Breadcrumb.Section> : ''}
       </Breadcrumb>
-      {/*{ this.state.isAuthenticated ? <div style={{float: 'right'}}>*/}
-        {/*<Popup*/}
-          {/*trigger={<Button onClick={() => this.showApiKey()} size='mini'>Show API Key</Button>}*/}
-          {/*content={this.state.apiKey ? this.state.apiKey.toString() : 'Loading API Key...'}*/}
-          {/*on='click'*/}
-          {/*positioning='top right'*/}
-        {/*/>*/}
-      {/*</div> : ''}*/}
     </section>)
   }
 }

--- a/dev-portal/src/components/QspHeader/index.js
+++ b/dev-portal/src/components/QspHeader/index.js
@@ -33,7 +33,7 @@ export default class QspHeader extends PureComponent {
     super(props);
 
     this.state = {
-      isAuthenticated: isAuthenticated()
+      isAuthenticated: isAuthenticated(),
     };
 
     // TODO: Code below are legacy. To find out what does it mean in relation with AWS.
@@ -51,7 +51,7 @@ export default class QspHeader extends PureComponent {
     // ********************************************************************************
   }
 
-  handleSignIn(d) {
+  handleAuthChange(d) {
     this.setState({isAuthenticated: d.signedIn});
   }
 
@@ -69,7 +69,7 @@ export default class QspHeader extends PureComponent {
           <h1>Information service for personalized nutrition and lifestyle advice</h1>
           <Button.Group>
             <SignIn usagePlanId={this.state.usagePlanId} token={this.state.token}
-                    onChange={(d) => this.handleSignIn(d)}/>
+                    onChange={(d) => this.handleAuthChange(d)}/>
             <Button.Or/>
             <Register usagePlanId={this.state.usagePlanId} token={this.state.token}/>
           </Button.Group>
@@ -79,7 +79,9 @@ export default class QspHeader extends PureComponent {
   }
 
   renderToolbar() {
-    return <QspMenu onChange={(d) => this.handleSignIn(d)}/>;
+    return (<div>
+      <QspMenu onChange={(d) => this.handleAuthChange(d)}/>
+    </div>);
   }
 
   render() {

--- a/dev-portal/src/components/QspHeader/index.js
+++ b/dev-portal/src/components/QspHeader/index.js
@@ -79,9 +79,7 @@ export default class QspHeader extends PureComponent {
   }
 
   renderToolbar() {
-    return (<div>
-      <QspMenu onChange={(d) => this.handleAuthChange(d)}/>
-    </div>);
+    return <QspMenu onChange={(d) => this.handleAuthChange(d)}/>;
   }
 
   render() {

--- a/dev-portal/src/components/QspMenu/index.js
+++ b/dev-portal/src/components/QspMenu/index.js
@@ -20,21 +20,28 @@ import {Menu, Dropdown} from 'semantic-ui-react'
 import {Image} from 'semantic-ui-react'
 import logo from './logo.png'
 import './QspMenu.css'
-import {isAuthenticated, logout} from "../../services/self"
+import {isAuthenticated, logout, showApiKey} from "../../services/self"
+import Popup from "semantic-ui-react/dist/es/modules/Popup/Popup";
 
 
 export default class QspMenu extends PureComponent {
 
   constructor(props) {
     super(props);
-    this.state = {signedIn: isAuthenticated()};
+    this.state = {signedIn: isAuthenticated(), apiKey: ''};
   }
 
   handleLogout() {
-    const _state = {signedIn: false};
+    const _state = {signedIn: false, apiKey: ''};
     logout();
     this.setState(_state);
     this.props.onChange(_state);
+  }
+
+  showApiKey() {
+    showApiKey().then(apiKey => {
+      this.setState({ apiKey })
+    })
   }
 
   render() {
@@ -54,6 +61,12 @@ export default class QspMenu extends PureComponent {
                 <Dropdown.Item href='/account-details'>
                   Account
                 </Dropdown.Item>
+                <Popup
+                  trigger={<Menu.Item onClick={() => this.showApiKey()}>Show API Key</Menu.Item>}
+                  content={this.state.apiKey ? this.state.apiKey.toString() : 'Loading API Key...'}
+                  on='click'
+                  positioning='left'
+                />
                 <Dropdown.Item onClick={() => this.handleLogout()}>
                   Sign Out
                 </Dropdown.Item>

--- a/dev-portal/src/components/QspMenu/index.js
+++ b/dev-portal/src/components/QspMenu/index.js
@@ -16,12 +16,10 @@
 
 import React, {PureComponent} from 'react'
 import {Link, Redirect} from 'react-router-dom'
-import {Menu, Dropdown} from 'semantic-ui-react'
-import {Image} from 'semantic-ui-react'
+import {Menu, Popup, Image, Dropdown} from 'semantic-ui-react'
 import logo from './logo.png'
 import './QspMenu.css'
 import {isAuthenticated, logout, showApiKey} from "../../services/self"
-import Popup from "semantic-ui-react/dist/es/modules/Popup/Popup";
 
 
 export default class QspMenu extends PureComponent {

--- a/dev-portal/src/pages/ApiDetails/index.js
+++ b/dev-portal/src/pages/ApiDetails/index.js
@@ -1,8 +1,8 @@
 import React, { PureComponent } from 'react'
 import { Dimmer, Loader} from 'semantic-ui-react'
 import { getApi } from '../../services/api-catalog'
-import Head from '../../components/Head'
 import SwaggerUI from "../../components/SwaggerUI";
+import QspBreadcrumb from '../../components/QspBreadcrumb'
 
 export default class ApiDetailsPage extends PureComponent {
   constructor(props) {
@@ -19,7 +19,7 @@ export default class ApiDetailsPage extends PureComponent {
 
   render() {
     return (<div>
-      <Head {...this.props} />
+      <QspBreadcrumb {...this.props} />
       <section className="swagger-section" style={{overflow: 'auto'}}>
         {this.state.api ? <SwaggerUI spec={this.state.api.swagger}/> : (
           <Dimmer active>

--- a/dev-portal/src/pages/Apis/index.js
+++ b/dev-portal/src/pages/Apis/index.js
@@ -3,7 +3,7 @@ import { Dimmer, Loader } from 'semantic-ui-react'
 import ApiCatalog from '../../components/ApiCatalog'
 import { isAuthenticated } from '../../services/self'
 import { getCatalog, fetchSubscriptions } from '../../services/api-catalog'
-import Head from '../../components/Head'
+import QspBreadcrumb from '../../components/QspBreadcrumb'
 
 export default class ApisPage extends PureComponent {
   constructor(props) {
@@ -23,7 +23,7 @@ export default class ApisPage extends PureComponent {
 
   render() {
     return (<div>
-      <Head {...this.props} />
+      <QspBreadcrumb {...this.props} />
       {this.state.catalog && (!isAuthenticated() || this.state.subscriptions) ? <ApiCatalog catalog={this.state.catalog} /> : (<Dimmer active>
         <Loader content='Loading' />
       </Dimmer>)}

--- a/dev-portal/src/pages/CaseStudies/index.js
+++ b/dev-portal/src/pages/CaseStudies/index.js
@@ -1,9 +1,9 @@
 import React from 'react'
-import Head from '../../components/Head'
+import QspBreadcrumb from '../../components/QspBreadcrumb'
 
 export default (props) => (
   <div>
-    <Head {...props} />
+    <QspBreadcrumb {...props} />
     <h2>Case Studies</h2>
     <p>Sample data. You can modify this static content in (‘/developer portal’) folder of the ‘link to github’ application.</p>
     <h3>Pet Availability</h3>

--- a/dev-portal/src/pages/GettingStarted/index.js
+++ b/dev-portal/src/pages/GettingStarted/index.js
@@ -1,9 +1,9 @@
 import React from 'react'
-import Head from '../../components/Head'
+import QspBreadcrumb from '../../components/QspBreadcrumb'
 
 export default (props) => (
   <div>
-    <Head {...props} />
+    <QspBreadcrumb {...props} />
     <h2>Getting Started</h2>
     <p>Sample data. You can modify this static content in `/dev-portal/src/pages/GettingStarted/index.js` folder.</p>
     <h3>Get Started with our PetStore API</h3>


### PR DESCRIPTION
Changes:
- renamed Head to QspBreadcrumb
- moved API key to menu
- propagate logout to api key

Fixes https://jira.thehyve.nl/browse/EITQSP-47.