### PR TITLE
Update API key name backend

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,4 @@ trim_trailing_whitespace = true
 [*.{js,json,html,css,yaml,yml}]
 indent_style = space
 indent_size = 2
+continuation_indent_size = 4

--- a/cloudformation/base.yaml
+++ b/cloudformation/base.yaml
@@ -297,12 +297,14 @@ Resources:
         AttributeType: S
       - AttributeName: MarketplaceCustomerId
         AttributeType: S
+      - AttributeName: ApiKeyId
+        AttributeType: S
       KeySchema:
       - AttributeName: Id
         KeyType: HASH
       ProvisionedThroughput:
-        ReadCapacityUnits: '5'
-        WriteCapacityUnits: '5'
+        ReadCapacityUnits: '1'
+        WriteCapacityUnits: '1'
       GlobalSecondaryIndexes:
       - IndexName: MarketplaceCustomerIdIndex
         KeySchema:
@@ -313,8 +315,8 @@ Resources:
           - ApiKeyId
           ProjectionType: INCLUDE
         ProvisionedThroughput:
-          ReadCapacityUnits: '5'
-          WriteCapacityUnits: '5'
+          ReadCapacityUnits: '1'
+          WriteCapacityUnits: '1'
 
   DevPortalLambdaExecutionRole:
     Type: AWS::IAM::Role

--- a/dev-portal/src/components/Register/index.js
+++ b/dev-portal/src/components/Register/index.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react'
-import { Button, Form, Message, Modal } from 'semantic-ui-react'
+import {Button, Form, Label, Message, Modal} from 'semantic-ui-react'
 import { Redirect } from 'react-router-dom'
 import { register } from '../../services/self'
 import { confirmMarketplaceSubscription } from '../../services/api-catalog'
@@ -9,13 +9,14 @@ import { confirmMarketplaceSubscription } from '../../services/api-catalog'
     isSubmitting: false,
     signedIn: false,
     errorMessage: '',
+    email: '',
     isOpen: false,
     validValues: {},
     password: '',
     confirmPassword: '',
   };
 
-  open = () => this.setState({ isSubmitting: false, errorMessage: '', validValues: {}, isOpen: true, password: '', confirmPassword: '' });
+  open = () => this.setState({ isSubmitting: false, errorMessage: '', validValues: {}, isOpen: true, password: '', confirmPassword: '', email: ''});
   close = () => this.setState({ isOpen: false });
   handleRegister = (...args) => this._handleRegister(...args);
 
@@ -43,22 +44,22 @@ import { confirmMarketplaceSubscription } from '../../services/api-catalog'
   }
 
   validateEmail = (event) => {
-    const val = event.target.value.trim();
-    const atSymbolIndex = val.indexOf('@');
-    const dotSymbolIndex = val.lastIndexOf('.');
+    const email = event.target.value.trim();
+    const atSymbolIndex = email.indexOf('@');
+    const dotSymbolIndex = email.lastIndexOf('.');
 
     let { errorMessage } = this.state;
     const validValues = Object.assign({}, this.state.validValues);
 
     validValues['email'] = true;
 
-    if (val.length < 5) {
+    if (email.length < 5) {
       validValues['email'] = false;
       errorMessage =  'Email address invalid.';
-    } else if (val.length > 255) {
+    } else if (email.length > 255) {
       validValues['email'] = false;
       errorMessage =  'Email address too long.';
-    } else if (atSymbolIndex === -1 || val.lastIndexOf('@') !== atSymbolIndex) {
+    } else if (atSymbolIndex === -1 || email.lastIndexOf('@') !== atSymbolIndex) {
       validValues['email'] = false;
       errorMessage = '@-symbol placement invalid.';
     } else if (dotSymbolIndex === -1 || atSymbolIndex > dotSymbolIndex) {
@@ -66,7 +67,7 @@ import { confirmMarketplaceSubscription } from '../../services/api-catalog'
       errorMessage = 'Domain dot (.) placement invalid.';
     }
 
-    this.updateValidity({ validValues, errorMessage })
+    this.updateValidity({ validValues, errorMessage, email})
   };
 
   updateValidity = (args) => {
@@ -121,6 +122,20 @@ import { confirmMarketplaceSubscription } from '../../services/api-catalog'
     this.updateValidity({validValues, confirmPassword})
   };
 
+  validateApiClient = (event) => {
+    const client = event.target.value;
+    let {errorMessage} = this.state;
+    const validValues = Object.assign({}, this.state.validValues);
+    if (!/^[a-zA-Z_-]{0,254}$/.test(client)) {
+      validValues['apiClient'] = false;
+      errorMessage = 'API client should contain only alphanumeric characters or the symbols dash ' +
+        ' or underscore.'
+    } else {
+      validValues['apiClient'] = true;
+    }
+    this.updateValidity({validValues, errorMessage})
+  };
+
   isError = (element) => {
     return element in this.state.validValues && !this.state.validValues[element]
   };
@@ -147,7 +162,10 @@ import { confirmMarketplaceSubscription } from '../../services/api-catalog'
             <Form.Input type='email' label='Email' name='email' error={this.isError('email')} onBlur={this.validateEmail} />
             <Form.Input label='Name' name='name' error={this.isError('name')}  onBlur={this.validateNonEmpty('name')} required />
             <Form.Input label='Organisation' name='organisation' error={this.isError('organisation')} />
-            <Form.Input label='API client' name='apiClient' error={this.isError('apiClient')} />
+            <Form.Input label='API client' name='apiClient' error={this.isError('apiClient')} onBlur={this.validateApiClient}>
+              <input/>
+              <Label basic>:{this.state.email ? this.state.email : 'me@example.com'}</Label>
+            </Form.Input>
             <Form.Input type='password' label='Password' name='password' autoComplete='false' error={this.isError('password')} onBlur={this.validatePassword} />
             <Form.Input type='password' label='Confirm password' name='confirmPassword' autoComplete='false' error={this.isError('confirmPassword')} onChange={this.validateConfirmPassword}/>
             <Message error content={this.state.errorMessage} />

--- a/dev-portal/src/pages/Account/index.js
+++ b/dev-portal/src/pages/Account/index.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import { Form } from 'semantic-ui-react'
-import Head from '../../components/Head'
+import QspBreadcrumb from "../../components/QspBreadcrumb";
 
 export default class AccountDetails extends PureComponent {
 
@@ -14,7 +14,7 @@ export default class AccountDetails extends PureComponent {
   render() {
     return (
       <div>
-        <Head {...this.props} />
+        <QspBreadcrumb {...this.props} />
         <h2>Account Details</h2>
           <Form noValidate>
             <Form.Input type='email' label='Email' name='email' disabled/>

--- a/dev-portal/src/services/self.js
+++ b/dev-portal/src/services/self.js
@@ -134,6 +134,18 @@ export function logout() {
 }
 
 export function showApiKey() {
-  return apiGatewayClient.get('/apikey', {}, {}, {})
+  return cognitoUser.getUserAttributes((err, result) => {
+    if (err) {
+      return Promise.reject(err);
+    }
+    let params = {};
+    for (let i = 0; i < result.length; i++) {
+      if (result[i].getName() === 'custom:apiClient') {
+        params.apiClient = result[i].getValue();
+        break;
+      }
+    }
+    return apiGatewayClient.get('/apikey', params, {}, {})
       .then(({data}) => data.value)
+  });
 }

--- a/lambdas/_common/customers-controller.js
+++ b/lambdas/_common/customers-controller.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The Hyve B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 'use strict';
 const AWS = require('aws-sdk');
 
@@ -5,214 +21,276 @@ const dynamoDb = new AWS.DynamoDB.DocumentClient();
 const apigateway = new AWS.APIGateway();
 
 const customersTable = 'DevPortalCustomers';
-const cognitoClient = new AWS.CognitoIdentityServiceProvider({region: `${process.env.AWS_DEFAULT_REGION}`});
+const cognitoClient = new AWS.CognitoIdentityServiceProvider();
 
-function ensureUser(cognitoIdentityId, accessKey, error, callback) {
-    const customerId = cognitoIdentityId; // + '+' + keyId
+/**
+ * Get user from the database, create it and its API key otherwise.
+ * @param identity aws-serverless-express event identity
+ * @param error string callback
+ * @param callback user object callback, including Id, ApiKeyId and optionally MarketplaceCustomerId.
+ */
+function ensureUser(identity, error, callback) {
+    const {cognitoIdentityId} = identity;
 
     // ensure user is tracked in customer table
-    const getParams = {
-        TableName: customersTable,
-        Key: {
-            Id: customerId
-        }
+    const params = {
+      TableName: customersTable,
+      Key: {
+        Id: cognitoIdentityId
+      }
     };
-    dynamoDb.getItem(getParams, (err, data) => {
+    dynamoDb.get(params, (err, data) => {
         if (err) {
-            error(err)
+          console.log(`Failed to get user ${cognitoIdentityId} from DynamoDb`, err);
+          error(err)
         } else if (data.Item === undefined) {
-          createApiKey(cognitoIdentityId, error, (keyId) => {
+          createApiKey(identity, error, (key) => {
             const putParams = {
               TableName: customersTable,
               Item: {
-                Id: customerId,
-                ApiKeyId: keyId
+                Id: cognitoIdentityId,
+                ApiKeyId: key.id
               }
             };
 
-            dynamoDb.putItem(putParams, (customerErr, customerData) => {
+            dynamoDb.put(putParams, (customerErr, customerData) => {
               if (customerErr) {
+                console.log(`Failed to insert user DynamoDB item for user ${cognitoIdentityId}`, customerErr);
                 error(customerErr)
               } else {
-                console.log(`Created new customer in ddb with id ${customerId}`);
+                console.log(`Created new customer in ddb with id ${cognitoIdentityId}`);
                 callback(customerData)
               }
             })
           });
         } else {
-            console.log(`Customer exists with id ${customerId}`);
-            callback(data.Item)
+          console.log(`Customer exists with id ${cognitoIdentityId}`);
+          callback(data.Item)
         }
     })
 }
 
-function getCognitoIdentityId(marketplaceCustomerId, error, callback) {
+/**
+ * Get the Cognito identity from a marketplace customer ID.
+ * @param marketplaceCustomerId AWS Marketplace customer ID.
+ * @param error string callback
+ * @param callback user object callback, with Id and MarketplaceCustomerId.
+ */
+function getIdentityFromMarketplaceId(marketplaceCustomerId, error, callback) {
     const params = {
         TableName: customersTable,
         IndexName: "MarketplaceCustomerIdIndex",
         KeyConditionExpression: "MarketplaceCustomerId = :customerId",
         ExpressionAttributeValues: {
-            ":customerId": marketplaceCustomerId
+          ":customerId": {
+            S: marketplaceCustomerId
+          },
         },
         ProjectionExpression: "MarketplaceCustomerId, Id"
     };
     dynamoDb.query(params, (err, data) => {
         if (err) {
-            error(err)
-        } else if (data.Items === undefined || data.Items.length === 0) {
-            // no customer matching marketplaceCustomerId - this should be created during marketplace subscription redirect
-            error(`No customer is registered in the developer portal for marketplace customer ID ${marketplaceCustomerId}`)
-        } else {
-            callback(data.Items[0].Id)
-        }
-    })
-}
-
-function subscribe(cognitoIdentityId, usagePlanId, errFunc, callback) {
-    getUserApiKeyId(cognitoIdentityId, errFunc, (keyId) => {
-        console.log(`Get Api Key ${keyId}`);
-
-        if (!keyId) {
-            console.log(`No API Key found for customer ${cognitoIdentityId}`);
-
-            createApiKey(cognitoIdentityId, errFunc, (createData) => {
-                console.log(`Create API Key data: ${createData}`);
-                const keyId = createData.id;
-
-                console.log(`Got key ID ${keyId}`);
-
-                createUsagePlanKey(keyId, usagePlanId, errFunc, (createKeyData) => {
-                    callback(createKeyData)
-                })
-            })
-        } else {
-            console.log(`Got key ID ${keyId}`);
-
-            createUsagePlanKey(keyId, usagePlanId, errFunc, (createKeyData) => {
-                callback(createKeyData)
-            })
-        }
-    })
-}
-
-function unsubscribe(cognitoIdentityId, usagePlanId, error, success) {
-  getUserApiKeyId(cognitoIdentityId, error, (keyId) => {
-        console.log(`Get Api Key data ${keyId}`);
-
-        if (!keyId) {
-            console.log(`No API Key found for customer ${cognitoIdentityId}`);
-
-            error('Customer does not have an API Key')
-        } else {
-            console.log(`Found API Key for customer with ID ${keyId}`);
-
-            deleteUsagePlanKey(keyId, usagePlanId, error, (deleteData) => {
-                success(deleteData)
-            })
-        }
-    })
-}
-
-function createApiKey(cognitoIdentityId, error, callback) {
-    console.log(`Creating API Key for customer ${cognitoIdentityId}`);
-
-    // set the name to the cognito identity ID so we can query API Key for the cognito identity
-    const params = {
-        description: `Dev Portal API Key for ${cognitoIdentityId}`,
-        enabled: true,
-        generateDistinctId: true,
-        name: cognitoIdentityId
-    };
-
-    apigateway.createApiKey(params, (err, data) => {
-        if (err) {
-          console.log('createApiKey error', error);
+          console.log(`Failed to query marketplace customer ${marketplaceCustomerId}`, err);
           error(err)
-        } else if (!data) {
-          error('No response')
+        } else if (data.Items === undefined || data.Items.length === 0) {
+          // no customer matching marketplaceCustomerId - this should be created during marketplace subscription redirect
+          error(`No customer is registered in the developer portal for marketplace customer ID ${marketplaceCustomerId}`)
         } else {
-          callback(data.id);
+          callback({cognitoIdentityId: data.Items[0].Id})
         }
     })
 }
 
-function createUsagePlanKey(keyId, usagePlanId, error, callback) {
-    console.log(`Creating usage plan key for key id ${keyId} and usagePlanId ${usagePlanId}`);
+/**
+ * Subscribe a user to a usage plan. This ensures that the user has an API key, and subscribes that
+ * to the usage plan.
+ * @param identity aws-serverless-express event identity
+ * @param usagePlanId usage plan ID in the API Gateway
+ * @param error string callback
+ * @param callback api key object callback, id, name and value.
+ */
+function subscribe(identity, usagePlanId, error, callback) {
+  ensureApiKey(identity, error, (key) => {
+    console.log(`Creating usage plan key for key id ${key.id} and usagePlanId ${usagePlanId}`);
 
     const params = {
-        keyId,
-        keyType: 'API_KEY',
-        usagePlanId
+      keyId: key.id,
+      keyType: 'API_KEY',
+      usagePlanId
     };
     apigateway.createUsagePlanKey(params, (err, data) => {
-        if (err) error(err);
-        else callback(data)
-    })
+      if (err) {
+        console.log(`Failed to create usage plan key for user ${identity.cognitoIdentityId}, API key ${key.id} and usage plan ${usagePlanId}`, err);
+        error(err);
+      } else {
+        callback(data)
+      }
+    });
+  });
 }
 
-function deleteUsagePlanKey(keyId, usagePlanId, error, callback) {
+/**
+ * Unsubscribe a user from usage plan. This may use ensures that the user has an API key, and subscribes that
+ * to the usage plan.
+ * @param identity aws-serverless-express event identity
+ * @param usagePlanId usage plan ID in the API Gateway
+ * @param error string callback
+ * @param success no-arg callback
+ */
+function unsubscribe(identity, usagePlanId, error, success) {
+  getApiKeyId(identity, error, (keyId) => {
     console.log(`Deleting usage plan key for key id ${keyId} and usagePlanId ${usagePlanId}`);
 
     const params = {
-        keyId,
-        usagePlanId
+      keyId,
+      usagePlanId
     };
-    apigateway.deleteUsagePlanKey(params, (err, data) => {
-        if (err) error(err);
-        else callback(data)
-    })
+    apigateway.deleteUsagePlanKey(params, (err) => {
+      if (err) {
+        console.log(`Failed to delete usage plan key for user ${identity.cognitoIdentityId}, API key ${keyId} and usage plan ${usagePlanId}`, err);
+        error(err);
+      } else {
+        success();
+      }
+    });
+  });
 }
 
-function getApiKeyForCustomer(cognitoIdentityId, error, callback) {
-  console.log(`Getting API Key for customer  ${cognitoIdentityId}`);
+/**
+ * Create an API key for the user in the API Gateway. Do not call directly.
+ *
+ * @param identity aws-serverless-express event identity
+ * @param error string callback
+ * @param callback api key object callback, id, name and value.
+ */
+function createApiKey(identity, error, callback) {
+  constructApiKeyName(identity, error, (name) => {
+    const {cognitoIdentityId} = identity;
 
-  getUserApiKeyId(cognitoIdentityId, error, (apiKey) => {
-    if (apiKey) {
-      apigateway.getApiKey({apiKey, includeValue: true}, (err, data) => {
-        if (err) error(err);
-        else callback(data)
+    console.log(`Creating API Key with name ${name} for user ${cognitoIdentityId}`);
+
+    // set the name to the cognito identity ID so we can query API Key for the cognito identity
+    const params = {
+      description: `Dev Portal API Key for ${cognitoIdentityId}`,
+      enabled: true,
+      generateDistinctId: true,
+      name: name
+    };
+
+    apigateway.createApiKey(params, (err, data) => {
+      if (err || !data) {
+        console.log(`Failed to create API key for user ${cognitoIdentityId}`, err);
+        error(err)
+      } else {
+        callback(data);
+      }
+    });
+  });
+}
+
+/**
+ * Ensure that user has an API key and that it is stored in DynamoDB.
+ * @param identity aws-serverless-express event identity
+ * @param error string callback
+ * @param callback api key object callback, id, name and value.
+ */
+function ensureApiKey(identity, error, callback) {
+  console.log(`Getting API Key for customer ${identity.cognitoIdentityId}`);
+
+  getApiKeyId(identity, error, (keyId) => {
+    if (keyId) {
+      apigateway.getApiKey({apiKey: keyId, includeValue: true}, (err, data) => {
+        if (data) {
+          callback(data);
+        } else if (err.code === 'NotFoundException') {
+          console.log(`API key ${keyId} for id ${identity.cognitoIdentityId} not found`);
+          createAndStoreApiKey(identity, error, callback);
+        } else {
+          console.log(`Failed to get API key ${keyId} for user ${identity.cognitoIdentityId}`, err);
+          error(err);
+        }
       });
     } else {
-      callback(null);
+      createAndStoreApiKey(identity, error, callback);
     }
   });
 }
 
+/**
+ * Creates an API key for a user and stores its ID in DynamoDB. Do not call directly.
+ * @param identity aws-serverless-express event identity
+ * @param error string callback
+ * @param callback api key object callback, id, name and value.
+ */
+function createAndStoreApiKey(identity, error, callback) {
+  createApiKey(identity, error, (newKey) => {
+    console.log(`Storing API key ${newKey.id} for user ${identity.cognitoIdentityId}`);
+    const params = {
+      TableName: customersTable,
+      Key: {
+        Id: identity.cognitoIdentityId,
+      },
+      UpdateExpression: 'SET ApiKeyId = :apiKeyId',
+      ExpressionAttributeValues: {
+        ':apiKeyId': newKey.id
+      }
+    };
 
-function getUserApiKeyId(cognitoIdentityId, error, callback) {
-  console.log(`Getting API Key ID for customer  ${cognitoIdentityId}`);
+    // update DDB customer record with new API key id
+    dynamoDb.update(params, (err) => {
+      if (err) {
+        console.log(`Failed to store API key ${newKey.id} for user ${identity.cognitoIdentityId}`, err)
+      } else {
+        callback(newKey)
+      }
+    });
+  });
+}
 
-  const dbParams = {
+/**
+ * Get the stored API key ID of a user. This does not guarantee that the API key with that ID still exists.
+ *
+ * @param identity aws-serverless-express event identity
+ * @param error string callback
+ * @param callback api key object callback, id, name and value.
+ */
+function getApiKeyId(identity, error, callback) {
+  const {cognitoIdentityId} = identity;
+
+  console.log(`Getting API Key ID for customer ${cognitoIdentityId}`);
+
+  const params = {
     TableName: customersTable,
     Key: {
-      Id: {
-        S: cognitoIdentityId
-      }
+      Id: cognitoIdentityId,
     }
   };
 
-  dynamoDb.getItem(dbParams, (err, data) => {
+  dynamoDb.get(params, (err, data) => {
     if (err) {
+      console.log(`Cannot get API key ID from DynamoDB user ${cognitoIdentityId}`);
       error(err)
     } else if (data.Item === undefined) {
       console.log(`No API Key found for customer ${cognitoIdentityId}`);
       callback(null);
     } else {
-      console.log(`Got key ID ${keyId}`);
-      callback(data.Item.ApiKeyId)
+      const keyId = data.Item.ApiKeyId;
+      console.log(`Got API key ID ${keyId}`);
+      callback(keyId)
     }
   });
-
-  apigateway.getApiKey(params, (err, data) => {
-    if (err) error(err);
-    else callback(data)
-  })
 }
 
-function getUsagePlansForCustomer(cognitoIdentityId, error, callback) {
-    console.log(`Getting API Key for customer ${cognitoIdentityId}`);
+/**
+ * Get all usage plans that a user is subscribed to.
+ * @param identity aws-serverless-express event identity
+ * @param error string callback
+ * @param callback APIGateway.Types.UsagePlans callback
+ */
+function getUsagePlansForCustomer(identity, error, callback) {
+    console.log(`Getting usage plans for customer ${identity.cognitoIdentityId}`);
 
-    getUserApiKeyId(cognitoIdentityId, error, (keyId) => {
+    getApiKeyId(identity, error, (keyId) => {
         if (!keyId) {
             callback({data : {}})
         } else {
@@ -221,13 +299,57 @@ function getUsagePlansForCustomer(cognitoIdentityId, error, callback) {
                 limit: 1000
             };
             apigateway.getUsagePlans(params, (err, usagePlansData) => {
-                if (err) error(err);
-                else callback(usagePlansData)
+                if (err) {
+                  console.log(`Failed to get usage plans for user ${identity.cognitoIdentityId} with API key ${keyId}`, err);
+                  error(err);
+                } else {
+                  callback(usagePlansData)
+                }
             })
         }
     })
 }
 
+/**
+ * Get the user's API key usage for a usage plan. The start and end date may not be more than a year
+ * apart.
+ * @param identity aws-serverless-express event identity
+ * @param usagePlanId API Gateway usage plan ID
+ * @param startDate start date to get the usage from, string as yyyy-mm-dd, required.
+ * @param endDate end date, inclusive, to get the usage to, string as yyyy-mm-dd, required.
+ * @param error string callback
+ * @param callback APIGateway.Types.UsagePlans callback
+ */
+function getUsage(identity, usagePlanId, startDate, endDate, error, callback) {
+  getApiKeyId(identity, error, (keyId) => {
+    if (!keyId) {
+      error(`No API key stored for ${identity.cognitoIdentityId}`);
+    }
+    const params = {
+      endDate,
+      startDate,
+      usagePlanId,
+      keyId,
+      limit: 366
+    };
+
+    apigateway.getUsage(params, (err, data) => {
+      if (err) {
+        console.log(`Failed to get usage for user ${identity.cognitoIdentityId} with API key ${keyId} in usage plan ${usagePlanId}`, err);
+        error(err);
+      } else {
+        callback(data);
+      }
+    });
+  });
+}
+
+/**
+ * Get the usage plans corresponding to a AWS Marketplace product.
+ * @param productCode AWS Marketplace product code string.
+ * @param error string callback
+ * @param callback APIGateway.Types.UsagePlan callback
+ */
 function getUsagePlanForProductCode(productCode, error, callback) {
     console.log(`Getting Usage Plan for product ${productCode}`);
 
@@ -237,7 +359,8 @@ function getUsagePlanForProductCode(productCode, error, callback) {
     };
     apigateway.getUsagePlans(params, function(err, data) {
         if (err) {
-            error(err)
+          console.log(`Failed to get usage plans for product code ${productCode}`, err);
+          error(err)
         } else {
             console.log(`Got usage plans ${JSON.stringify(data.items)}`);
 
@@ -256,48 +379,51 @@ function getUsagePlanForProductCode(productCode, error, callback) {
     });
 }
 
-function updateCustomerMarketplaceId(cognitoIdentityId, marketplaceCustomerId, error, success) {
-    const dynamoDbParams = {
+/**
+ * Update the marketplace customer ID of a user in the DynamoDB.
+ * @param identity aws-serverless-express event identity
+ * @param marketplaceCustomerId market place customer ID
+ * @param error string callback
+ * @param success no-arg callback
+ */
+function updateCustomerMarketplaceId(identity, marketplaceCustomerId, error, success) {
+    const params = {
         TableName: customersTable,
         Key: {
-            Id: cognitoIdentityId
+          Id: identity.cognitoIdentityId
         },
-        UpdateExpression: 'set #a = :x',
-        ExpressionAttributeNames: { '#a': 'MarketplaceCustomerId' },
+        UpdateExpression: 'set MarketplaceCustomerId = :customerId',
         ExpressionAttributeValues: {
-            ':x': marketplaceCustomerId
+          ':customerId': {
+            S: marketplaceCustomerId
+          }
         }
     };
 
     // update DDB customer record with marketplace customer id
     // and update API Gateway API Key with marketplace customer id
-    dynamoDb.update(dynamoDbParams, (dynamoDbErr) => {
-        if (dynamoDbErr) {
-            error(dynamoDbErr)
+    dynamoDb.update(params, (err) => {
+        if (err) {
+          console.log(`Failed to update marketplace customer ID ${marketplaceCustomerId} in database item for user ${identity.cognitoIdentityId}`, err);
+          error(err)
         } else {
-            getUserApiKeyId(cognitoIdentityId, error, (keyId) => {
-                console.log(`Get Api Key data ${JSON.stringify(data)}`);
+            ensureApiKey(identity, error, (key) => {
+                console.log(`Got API key with ID ${key.id}`);
 
-                if (!keyId) {
-                    console.log(`No API Key found for customer ${cognitoIdentityId}`);
-
-                    createApiKey(cognitoIdentityId, errFunc, (createData) => {
-                        console.log(`Create API Key data: ${createData}`);
-                        success(createData);
-                    })
-                } else {
-                    console.log(`Got key ID ${keyId}`);
-
-                    updateApiKey(keyId, marketplaceCustomerId, error, (createKeyData) => {
-                        success(createKeyData)
-                    })
-                }
-            })
+                updateApiKeyCustomerId(key.id, marketplaceCustomerId, error, success);
+            });
         }
     })
 }
 
-function updateApiKey(apiKeyId, marketplaceCustomerId, error, success) {
+/**
+ * Set the marketplace customer ID in an API key. This ensures that the API key usage will be billed.
+ * @param apiKeyId API key ID
+ * @param marketplaceCustomerId market place customer ID
+ * @param error string callback
+ * @param success no-arg callback
+ */
+function updateApiKeyCustomerId(apiKeyId, marketplaceCustomerId, error, success) {
     console.log(`Updating API Key ${apiKeyId} in API Gateway with marketplace customer ID`);
 
     // update API Gateway API Key with marketplace customer id to support metering
@@ -312,103 +438,110 @@ function updateApiKey(apiKeyId, marketplaceCustomerId, error, success) {
         ]
     };
     apigateway.updateApiKey(params, function(err, data) {
-        if (err) error(err);
-        else     success(data)
+        if (err) {
+          console.log(`Failed to update customerId of API key ${apiKeyId}`, err);
+          error(err);
+        } else {
+          success(data)
+        }
     });
 }
 
-function updateCustomerApiKeyId(cognitoIdentityId, customerId, apiKeyId, error, success) {
-    // update customer record with marketplace customer code
-    const dynamoDbParams = {
-      TableName: customersTable,
-      Key: {
-        Id: cognitoIdentityId
-      },
+/**
+ * Construct a legible API key name. Do not call directly.
+ * @param identity aws-serverless-express event identity
+ * @param error string callback
+ * @param callback string callback
+ */
+function constructApiKeyName(identity, error, callback) {
+  getUserAttributes(identity, {Username: 'user', 'custom:apiClient': 'apiClient'}, error, (attrs) => {
+    if (!attrs || !attrs.user) {
+      callback(identity.cognitoIdentityId)
+    }
+    callback(attrs.apiClient ? `${attrs.apiClient}:${attrs.user}` : attrs.user);
+  });
+}
+
+/**
+ * Get the attributes of a user. This will include the 'user' attribute containing the username.
+ * @param identity aws-serverless-express event identity
+ * @param keyMap remaps attributes corresponding to the keys in the map to a new key that is listed in
+ *        the value. Keys that are not in this map are ignored.
+ *        E.g. keyMap = {a: 'a1'} will map {a: 1, b: 2} to {a1: 1}. If the keyMap is falsey, all
+ *        attributes are returned as is.
+ * @param error string callback
+ * @param callback string callback
+ */
+function getUserAttributes(identity, keyMap, error, callback) {
+  if (identity.cognitoUserPoolId && identity.user) {
+    const params = {
+      UserPoolId: identity.cognitoUserPoolId,
+      Username: identity.user,
     };
-    if (customerId) {
-      Object.assign(dynamoDbParams, {
-        UpdateExpression: 'set #a = :x, #b = :y',
-        ExpressionAttributeNames: {'#a': 'ApiKeyId', '#b': 'MarketplaceCustomerId'},
-        ExpressionAttributeValues: {
-          ':x': apiKeyId,
-          ':y': customerId,
+    cognitoClient.adminGetUser(params, (err, data) => {
+      if (err) {
+        callback({user: identity.user});
+      } else {
+        let userAttrs = Object.assign({}, data.UserAttributes, {Username: data.Username});
+        if (!userAttrs) {
+          callback(null);
         }
-      });
-    } else {
-      Object.assign(dynamoDbParams, {
-        UpdateExpression: 'set #a = :x',
-        ExpressionAttributeNames: {'#a': 'ApiKeyId'},
-        ExpressionAttributeValues: {
-          ':x': apiKeyId
+        let attrs = {};
+        for (let i = 0; i < userAttrs.length; i++) {
+          if (!keyMap) {
+            attrs[userAttrs[i].Name] = userAttrs[i].Value
+          } else if (userAttrs[i].Name in keyMap) {
+            attrs[keyMap[userAttrs[i].Name]] = userAttrs[i].Value;
+          }
         }
-      });
-    }
-
-    dynamoDb.update(dynamoDbParams, (dynamoDbErr) => {
-        if (dynamoDbErr) {
-            error(dynamoDbErr)
-        } else {
-            success()
-        }
-    })
+        callback(attrs);
+      }
+    });
+  } else {
+    callback({user: identity.user})
+  }
 }
 
-function constructApiKeyName(accessKey, error, callback) {
-  getUserAttributes(accessKey, {Username: 'user', 'custom:apiClient': 'apiClient'}, error, (attrs) => {
-    if (!('user' in attrs)) {
-      error('Username not set');
-    }
-    let response = attrs['user'];
-    if ('apiClient' in attrs && attrs['apiClient']) {
-      response = attrs['apiClient'] + ':' + response;
-    }
-    callback(response);
-  });
-}
+/**
+ * Subscribe a user to a AWS marketplace product.
+ * @param identity aws-serverless-express event identity
+ * @param marketplaceToken token that marketplace passes when subscribing to a new product
+ * @param usagePlanId API gateway usage plan ID to subscribe to.
+ * @param error string callback
+ * @param callback string callback
+ */
+function subscribeFromMarketplace(identity, marketplaceToken, usagePlanId, error, callback) {
+  const marketplace = new AWS.MarketplaceMetering();
 
-function getUserAttributes(accessKey, keyMap, error, callback) {
-  cognitoClient.getUser({AccessToken: accessKey}, (err, data) => {
+  const params = {
+    RegistrationToken: marketplaceToken
+  };
+
+  // call MMS to crack token into marketplace customer ID and product code
+  marketplace.resolveCustomer(params, (err, data) => {
     if (err) {
-      error(err);
+      console.log(`Failed to resolve customer from marketplaceToken ${marketplaceToken}`, err);
+      error(err)
     } else {
-      let userAttrs = Object.assign({}, data.UserAttributes, {Username: data.Username});
-      if (!userAttrs) {
-        callback(null);
-      }
-      let attrs = {};
-      for (let i = 0; i < userAttrs.length; i++) {
-        if (!keyMap) {
-          attrs[userAttrs[i].Name] = userAttrs[i].Value
-        } else if (userAttrs[i].Name in keyMap) {
-          attrs[keyMap[userAttrs[i].Name]] = userAttrs[i].Value;
-        }
-      }
-      callback(attrs);
+      // persist the marketplaceCustomerId in DDB
+      // this is used when the subscription listener receives the subscribe notification
+      const marketplaceCustomerId = data.CustomerIdentifier;
+      updateCustomerMarketplaceId(identity, marketplaceCustomerId, error,
+        () => subscribe(identity, usagePlanId, error, callback));
     }
-  });
+  })
 }
-
-// function getUsagePlans(error, callback) {
-//     const params = {
-//         limit: 1000
-//     }
-//     apigateway.getUsagePlans(params, (err, data) => {
-//         if (err) error(err)
-//         else callback(data)
-//     })
-// }
 
 module.exports = {
-    ensureCustomerItem: ensureCustomerItem,
-    subscribe: subscribe,
-    unsubscribe: unsubscribe,
-    createApiKey: createApiKey,
-    createUsagePlanKey: createUsagePlanKey,
-    deleteUsagePlanKey: deleteUsagePlanKey,
-    getApiKeyForCustomer: getApiKeyForCustomer,
-    getUserApiKeyId: getUserApiKeyId,
-    getUsagePlansForCustomer: getUsagePlansForCustomer,
-    getUsagePlanForProductCode: getUsagePlanForProductCode,
-    updateCustomerMarketplaceId: updateCustomerMarketplaceId,
-    getCognitoIdentityId: getCognitoIdentityId
+  ensureUser,
+  subscribe,
+  unsubscribe,
+  ensureApiKey,
+  getApiKeyId,
+  getUsagePlansForCustomer,
+  getUsagePlanForProductCode,
+  updateCustomerMarketplaceId,
+  getUsage,
+  subscribeFromMarketplace,
+  getIdentityFromMarketplaceId,
 };

--- a/lambdas/_common/customers-controller.js
+++ b/lambdas/_common/customers-controller.js
@@ -82,9 +82,7 @@ function getIdentityFromMarketplaceId(marketplaceCustomerId, error, callback) {
         IndexName: "MarketplaceCustomerIdIndex",
         KeyConditionExpression: "MarketplaceCustomerId = :customerId",
         ExpressionAttributeValues: {
-          ":customerId": {
-            S: marketplaceCustomerId
-          },
+          ":customerId": marketplaceCustomerId
         },
         ProjectionExpression: "MarketplaceCustomerId, Id"
     };
@@ -394,9 +392,7 @@ function updateCustomerMarketplaceId(identity, marketplaceCustomerId, error, suc
         },
         UpdateExpression: 'set MarketplaceCustomerId = :customerId',
         ExpressionAttributeValues: {
-          ':customerId': {
-            S: marketplaceCustomerId
-          }
+          ':customerId': marketplaceCustomerId
         }
     };
 

--- a/lambdas/backend/README.md
+++ b/lambdas/backend/README.md
@@ -2,9 +2,30 @@
 
 This is uploaded as a Lambda to AWS API gateway.
 
-To run a development server, run
+To run start development, run
 ```shell
 yarn install
-yarn add file:../_common
+yarn add --force file:../_common
+```
+
+In every session, or in your `~/.bashrc` or `~/.zshrc`, include
+```shell
+export AWS_SDK_LOAD_CONFIG=true
+```
+
+To test the code, run
+```shell
+yarn test
+```
+
+To make a local request including API Gateway context, run, e.g.,
+```shell
+yarn request '{"httpMethod": "GET", "path": "/catalog"}'
+# to parse the output with jq, use for example:
+(yarn request '{"httpMethod": "GET", "path": "/catalog"}' 2>&1 >/dev/null ) | jq
+```
+
+To run a local server, run
+```shell
 yarn local
 ```

--- a/lambdas/backend/express-server-local.js
+++ b/lambdas/backend/express-server-local.js
@@ -1,5 +1,0 @@
-const app = require('./express-server')
-const port = 4000
-
-app.listen(port)
-console.log(`listening on http://localhost:${port}`)

--- a/lambdas/backend/express-server.js
+++ b/lambdas/backend/express-server.js
@@ -1,16 +1,30 @@
+/*
+ * Copyright (c) 2018 The Hyve B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 'use strict';
 
 const express = require('express');
 const bodyParser = require('body-parser');
 const cors = require('cors');
 const util = require('util');
-const AWS = require('aws-sdk');
 const awsServerlessExpressMiddleware = require('aws-serverless-express/middleware');
 const catalog = require('./catalog');
 const customersController = require('common-lambda-assets/customers-controller.js');
 
 const app = express();
-const apigateway = new AWS.APIGateway();
 
 // replace these to match your site URL. Note: Use TLS, not plain HTTP, for your production site!
 const domain = `${process.env.CLIENT_BUCKET_NAME}.s3-website.${process.env.AWS_DEFAULT_REGION}.amazonaws.com`;
@@ -21,165 +35,67 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(awsServerlessExpressMiddleware.eventContext());
 
-// no auth
-// app.post('/register', (req, res) => {
-//     console.log(util.inspect(req))
-//
-//     res.json({})
-// })
+// authorization is handled in the CloudFormation API gateway definition.
 
 app.post('/signin', (req, res) => {
-    const cognitoIdentityId = getCognitoIdentityId(req);
-
-    function errFunc(data) {
-        console.log(`error: ${data}`);
-        res.status(500).json(data)
-    }
-
-    // ensure an API Key exists for this customer and that the Cognito identity and API Key Id are tracked in DDB
-    customersController.getApiKeyForCustomer(cognitoIdentityId, errFunc, (data) => {
-        console.log(`Get Api Key data ${JSON.stringify(data)}`);
-
-        if (data.items.length === 0) {
-            console.log(`No API Key found for customer ${cognitoIdentityId}`);
-
-            customersController.createApiKey(cognitoIdentityId, null, errFunc, (createData) => {
-                console.log(`Create API Key data: ${createData}`);
-                const keyId = createData.id;
-
-                console.log(`Got key ID ${keyId}`);
-
-                customersController.ensureCustomerItem(cognitoIdentityId, keyId, errFunc,
-                    () => res.status(200).json({}))
-            })
-        } else {
-            const keyId = data.items[0].id;
-
-            customersController.ensureCustomerItem(cognitoIdentityId, keyId, errFunc,
-                () => res.status(200).json({}))
-        }
-    })
+  customersController.ensureUser(getIdentity(req), error(res), success(res));
 });
 
+// no auth
 // the API catalog could be statically defined (catalog/index.js), or generated from API Gateway Usage Plans (See getUsagePlans())
 app.get('/catalog', (req, res) => {
     res.status(200).json(catalog)
 });
 
 app.get('/apikey', (req, res) => {
-    const cognitoIdentityId = getCognitoIdentityId(req);
-
-    function errFunc(data) {
-        console.log(`error: ${data}`);
-        res.status(500).json(data)
-    }
-
-    customersController.getApiKeyForCustomer(cognitoIdentityId, errFunc, (data) => {
-        if (data.items.length === 0) {
-            res.status(404).json('No API Key for customer')
-        } else {
-            const item = data.items[0];
-            const key = {
-                id: item.id,
-                value: item.value
-            };
-            res.status(200).json(key)
-        }
-    })
+  customersController.ensureApiKey(getIdentity(req), error(res), (key) => {
+    const data = {
+      id: key.id,
+      value: key.value
+    };
+    res.status(200).json(data)
+  });
 });
 
 app.get('/subscriptions', (req, res) => {
-    console.log(`GET /subscriptions for Cognito ID: ${req.apiGateway.event.requestContext.identity.cognitoIdentityId}`)
+  console.log(`GET /subscriptions`);
 
-    function errFunc(data) {
-        console.log(`error: ${data}`);
-        res.status(500).json(data)
-    }
-
-    customersController.getUsagePlansForCustomer(req.apiGateway.event.requestContext.identity.cognitoIdentityId, errFunc, (data) => {
-        res.status(200).json(data.items)
-    })
+  customersController.getUsagePlansForCustomer(getIdentity(req), error(res), (data) => {
+      res.status(200).json(data.items)
+  });
 });
 
 app.put('/subscriptions/:usagePlanId', (req, res) => {
-    const cognitoIdentityId = getCognitoIdentityId(req);
-    const usagePlanId = req.params.usagePlanId;
+  const usagePlanId = req.params.usagePlanId;
 
-    const isUsagePlanInCatalog = Boolean(getUsagePlanFromCatalog(usagePlanId))
-
-    function error(data) {
-        console.log(`error: ${data}`);
-        res.status(500).json(data)
-    }
-
-    function success(data) {
-       res.status(201).json(data)
-    }
-
-    if (!isUsagePlanInCatalog) {
-        res.status(404).json('Invalid Usage Plan ID')
-    } else {
-        customersController.subscribe(cognitoIdentityId, usagePlanId, error, success)
-    }
+  if (getUsagePlanFromCatalog(usagePlanId)) {
+    customersController.subscribe(getIdentity(req), usagePlanId, error(res),
+        (data) => res.status(201).json(data));
+  } else {
+    res.status(404).json('Invalid Usage Plan ID')
+  }
 });
 
 app.get('/subscriptions/:usagePlanId/usage', (req, res) => {
-    const cognitoIdentityId = getCognitoIdentityId(req);
-    const usagePlanId = req.params.usagePlanId;
+  const usagePlanId = req.params.usagePlanId;
 
-    function errFunc(data) {
-        console.log(`error: ${data}`);
-        res.status(500).json(data)
-    }
-
-    const isUsagePlanInCatalog = Boolean(getUsagePlanFromCatalog(usagePlanId));
-
-    // could error here if customer is not subscribed to usage plan, or save an extra request by just showing 0 usage
-    if (!isUsagePlanInCatalog) {
-        res.status(404).json('Invalid Usage Plan ID')
-    } else {
-        customersController.getUserApiKeyId(cognitoIdentityId, errFunc, (keyId) => {
-            const params = {
-                endDate: req.query.end,
-                startDate: req.query.start,
-                usagePlanId,
-                keyId,
-                limit: 1000
-            };
-
-            apigateway.getUsage(params, (err, usageData) => {
-                if (err) {
-                    console.log(`get usage err ${JSON.stringify(err)}`);
-                    errFunc(err)
-                } else {
-                    console.log(`get usage data ${JSON.stringify(usageData)}`);
-                    res.status(200).json(usageData)
-                }
-            })
-        })
-    }
+  // could error here if customer is not subscribed to usage plan, or save an extra request by just showing 0 usage
+  if (getUsagePlanFromCatalog(usagePlanId)) {
+    customersController.getUsage(getIdentity(req), usagePlanId, req.query.start, req.query.end,
+      error(res), success(res));
+  } else {
+    res.status(404).json('Invalid Usage Plan ID')
+  }
 });
 
 app.delete('/subscriptions/:usagePlanId', (req, res) => {
-    const cognitoIdentityId = getCognitoIdentityId(req);
-    const usagePlanId = req.params.usagePlanId;
+  const usagePlanId = req.params.usagePlanId;
 
-    function error(data) {
-        console.log(`error: ${data}`);
-        res.status(500).json(data)
-    }
-
-    function success(data) {
-        res.status(200).json(data)
-    }
-
-    const isUsagePlanInCatalog = Boolean(getUsagePlanFromCatalog(usagePlanId));
-
-    if (!isUsagePlanInCatalog) {
-        res.status(404).json('Invalid Usage Plan ID')
-    } else {
-        customersController.unsubscribe(cognitoIdentityId, usagePlanId, error, success)
-    }
+  if (getUsagePlanFromCatalog(usagePlanId)) {
+    customersController.unsubscribe(getIdentity(req), usagePlanId, error(res), success(res));
+  } else {
+    res.status(404).json('Invalid Usage Plan ID')
+  }
 });
 
 // no auth
@@ -205,57 +121,31 @@ app.post('/marketplace-confirm/:usagePlanId', (req, res) => {
 });
 
 app.put('/marketplace-subscriptions/:usagePlanId', (req, res) => {
-    const marketplaceToken = req.body.token;
-    const usagePlanId = req.params.usagePlanId;
-    console.log(`Marketplace token: ${marketplaceToken} usage plan id: ${usagePlanId}`);
-    const cognitoIdentityId = getCognitoIdentityId(req);
-    console.log(`cognito id: ${cognitoIdentityId}`);
+  const marketplaceToken = req.body.token;
+  const usagePlanId = req.params.usagePlanId;
+  console.log(`Marketplace token: ${marketplaceToken}, usage plan id: ${usagePlanId}, cognito ID: ${identity.cognitoIdentityId} `);
 
-    function error(data) {
-        console.log(`error: ${data}`);
-        res.status(500).json(data)
-    }
-
-    function success(data) {
-        res.status(200).json(data)
-    }
-
-    function subscribeCustomerToUsagePlan(data) {
-        customersController.subscribe(cognitoIdentityId, usagePlanId, error, success)
-    }
-
-    const marketplace = new AWS.MarketplaceMetering();
-
-    const params = {
-        RegistrationToken: marketplaceToken
-    };
-
-    // call MMS to crack token into marketplace customer ID and product code
-    marketplace.resolveCustomer(params, (err, data) => {
-        if (err) {
-            console.log(`marketplace error: ${JSON.stringify(err)}`);
-            res.status(400).json(err.message)
-        } else {
-            console.log(`marketplace data: ${JSON.stringify(data)}`);
-
-            // persist the marketplaceCustomerId in DDB
-            // this is used when the subscription listener receives the subscribe notification
-            const marketplaceCustomerId = data.CustomerIdentifier;
-            customersController.updateCustomerMarketplaceId(cognitoIdentityId, marketplaceCustomerId, error, subscribeCustomerToUsagePlan)
-        }
-    })
+  customersController.subscribeFromMarketplace(getIdentity(req), marketplaceToken, usagePlanId, error(res), success(res));
 });
 
-function getCognitoIdentityId(req) {
-    return req.apiGateway.event.requestContext.identity.cognitoIdentityId
-}
-
-function getAccessKey(req) {
-  return req.apiGateway.event.requestContext.identity.accessKey;
+/** Get the identity provided by API Gateway. See scripts/api-gateway-event.json for an example. */
+function getIdentity(req) {
+  return req.apiGateway.event.requestContext.identity;
 }
 
 function getUsagePlanFromCatalog(usagePlanId) {
   return catalog.find(c => c.id === usagePlanId)
+}
+
+function error(res) {
+  return (data) => {
+    console.log(`error: ${data}`);
+    res.status(500).json(data)
+  };
+}
+
+function success(res) {
+  return (data) => res.status(200).json(data);
 }
 
 // The aws-serverless-express library creates a server and listens on a Unix

--- a/lambdas/backend/express-server.js
+++ b/lambdas/backend/express-server.js
@@ -43,7 +43,7 @@ app.post('/signin', (req, res) => {
         if (data.items.length === 0) {
             console.log(`No API Key found for customer ${cognitoIdentityId}`);
 
-            customersController.createApiKey(cognitoIdentityId, errFunc, (createData) => {
+            customersController.createApiKey(cognitoIdentityId, null, errFunc, (createData) => {
                 console.log(`Create API Key data: ${createData}`);
                 const keyId = createData.id;
 
@@ -138,9 +138,7 @@ app.get('/subscriptions/:usagePlanId/usage', (req, res) => {
     if (!isUsagePlanInCatalog) {
         res.status(404).json('Invalid Usage Plan ID')
     } else {
-        customersController.getApiKeyForCustomer(cognitoIdentityId, errFunc, (data) => {
-            const keyId = data.items[0].id;
-
+        customersController.getUserApiKeyId(cognitoIdentityId, errFunc, (keyId) => {
             const params = {
                 endDate: req.query.end,
                 startDate: req.query.start,
@@ -190,7 +188,7 @@ app.delete('/subscriptions/:usagePlanId', (req, res) => {
 app.post('/marketplace-confirm/:usagePlanId', (req, res) => {
     const marketplaceToken = req.body['x-amzn-marketplace-token'];
 
-    if (marketplaceToken === null || marketplaceToken === undefined) {
+    if (!marketplaceToken) {
         console.log(`Couldn't find marketplace token. Event: ${util.inspect(req.apiGateway.event, { depth: null, colors: true })}`);
         res.status(400).json({ message: 'Missing AWS Marketplace token' })
     }
@@ -250,6 +248,10 @@ app.put('/marketplace-subscriptions/:usagePlanId', (req, res) => {
 
 function getCognitoIdentityId(req) {
     return req.apiGateway.event.requestContext.identity.cognitoIdentityId
+}
+
+function getAccessKey(req) {
+  return req.apiGateway.event.requestContext.identity.accessKey;
 }
 
 function getUsagePlanFromCatalog(usagePlanId) {

--- a/lambdas/backend/index.js
+++ b/lambdas/backend/index.js
@@ -1,6 +1,6 @@
-'use strict'
-const awsServerlessExpress = require('aws-serverless-express')
-const app = require('./express-server')
-const server = awsServerlessExpress.createServer(app)
+'use strict';
+const awsServerlessExpress = require('aws-serverless-express');
+const app = require('./express-server');
+const server = awsServerlessExpress.createServer(app);
 
-exports.handler = (event, context) => awsServerlessExpress.proxy(server, event, context)
+exports.handler = (event, context) => awsServerlessExpress.proxy(server, event, context);

--- a/lambdas/backend/package.json
+++ b/lambdas/backend/package.json
@@ -3,19 +3,28 @@
   "version": "1.0.0",
   "description": "Example application for running a Serverless Developer Portal with API Gateway and Lambda",
   "main": "index.js",
-  "config": {},
+  "config": {
+    "region": "eu-central-1",
+    "accountId": "qsp",
+    "s3BucketName": "QspTestDevPortalArtifacts"
+  },
   "scripts": {
-    "local": "node ./express-server-local"
+    "local": "node scripts/express-server-local",
+    "request": "node scripts/request",
+    "test": "tap test/*.js"
   },
   "license": "Apache-2.0",
   "dependencies": {
     "aws-sdk": "^2.7.10",
-    "aws-serverless-express": "^1.1.4",
+    "aws-serverless-express": "3.2.0",
     "body-parser": "^1.15.2",
     "common-lambda-assets": "file:../_common",
     "cors": "^2.8.1",
     "express": "^4.14.0",
     "js-yaml": "^3.7.0"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "merge-options": "^1.0.1",
+    "tap": "^11.1.4"
+  }
 }

--- a/lambdas/backend/scripts/api-gateway-event.json
+++ b/lambdas/backend/scripts/api-gateway-event.json
@@ -1,0 +1,50 @@
+{
+  "httpMethod": "POST",
+  "path": "/signin",
+  "//body": "{}",
+  "resource": "/signin",
+  "queryStringParameters": {},
+  "pathParameters": {},
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, sdch, br",
+    "Accept-Language": "en-US,en;q=0.8",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Content-Type": "application/json",
+    "Host": "xxxxxxxxxx.execute-api.us-east-1.amazonaws.com",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36",
+    "Via": "1.1 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_xxxxxxxxxxx_xxxx==",
+    "X-Forwarded-For": "11.111.111.111, 11.111.111.111",
+    "X-Forwarded-Port": "111",
+    "X-Forwarded-Proto": "http"
+  },
+  "requestContext": {
+    "accountId": "111111111111",
+    "resourceId": "xxxxxx",
+    "stage": "prod",
+    "requestId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "identity": {
+      "cognitoIdentityPoolId": "eu-central-1_r8GFpSaUO",
+      "accountId": "",
+      "cognitoIdentityId": "eu-central-1:796ba4ba-5275-47d3-89e3-683a9b7f05ae",
+      "caller": "",
+      "apiKey": "",
+      "sourceIp": "11.111.111.111",
+      "cognitoAuthenticationType": "",
+      "cognitoAuthenticationProvider": "",
+      "userArn": "",
+      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36",
+      "user": "joris@thehyve.nl"
+    },
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "GET",
+    "apiId": "xxxxxxxxxx"
+  }
+}

--- a/lambdas/backend/scripts/express-server-local.js
+++ b/lambdas/backend/scripts/express-server-local.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2018 The Hyve B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const app = require('../express-server');
+const port = 4000;
+
+app.listen(port);
+console.log(`listening on http://localhost:${port}`);

--- a/lambdas/backend/scripts/request.js
+++ b/lambdas/backend/scripts/request.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2018 The Hyve B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const lambdaFunction = require('../index');
+const apiGatewayEvent = require('./api-gateway-event.json');
+
+if (process.argv.length > 2) {
+  let apiGatewayUpdate = JSON.parse(process.argv[2]);
+  if (apiGatewayUpdate.path && !apiGatewayUpdate.resource) {
+    apiGatewayUpdate.resource = apiGatewayUpdate.path;
+  }
+  Object.assign(apiGatewayEvent, apiGatewayUpdate);
+}
+
+const server = lambdaFunction.handler(apiGatewayEvent, {
+  succeed: v => {
+    console.error(JSON.stringify(v));
+    process.exit(0)
+  }
+}, (e, v) => {
+  console.error(v);
+  process.exit(1)
+});
+
+process.stdin.resume();
+
+function exitHandler(options, err) {
+  if (options.cleanup && server && server.close ) {
+    server.close()
+  }
+
+  if (err) console.error(err.stack);
+  if (options.exit) process.exit()
+}
+
+process.on('exit', exitHandler.bind(null, { cleanup: true }));
+process.on('SIGINT', exitHandler.bind(null, { exit: true })); // ctrl+c event
+process.on('SIGTSTP', exitHandler.bind(null, { exit: true })); // ctrl+v event
+process.on('uncaughtException', exitHandler.bind(null, { exit: true }));

--- a/lambdas/backend/test/integration.js
+++ b/lambdas/backend/test/integration.js
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2018 The Hyve B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const tap = require('tap');
+const mergeOptions = require('merge-options');
+
+const lambdaFunction = require('../index');
+const apiGatewayEvent = require('../scripts/api-gateway-event.json');
+
+let server = null;
+
+/**
+ * Make a request to the API.
+ *
+ * @param apiGatewayUpdate updated properties of the event defined in api-gateway-event.
+ * @returns {Promise<{statusCode, body, headers, isBase64Encoded}>} response
+ */
+function makeRequest(apiGatewayUpdate) {
+  return new Promise(resolve => {
+    if (apiGatewayUpdate.path && !apiGatewayUpdate.resource) {
+      apiGatewayUpdate.resource = apiGatewayUpdate.path;
+    }
+    let event = mergeOptions(apiGatewayEvent, apiGatewayUpdate);
+    server = lambdaFunction.handler(event, {
+      succeed: (data) => {
+        resolve(data);
+      }
+    });
+  });
+}
+
+/**
+ * Use tap to test the outcome of a promise.
+ * @param name test name
+ * @param callback test callback.
+ */
+function testPromise(name, callback) {
+  tap.test(name, test => {
+    callback(test)
+        // .then(() => new Promise(resolve => setTimeout(resolve, 500)))
+        .then(() => test.end())
+        .catch((v) => {
+          test.fail(v);
+          test.end();
+        });
+  });
+}
+
+testPromise('sign in', test => {
+  let request = {
+    httpMethod: 'POST',
+    path: '/signin'
+  };
+  return makeRequest(request)
+      .then(res => test.equal(res.statusCode, 200, "sign in failed", res));
+});
+
+testPromise('fail sign in without credentails', test => {
+  let request = {
+    httpMethod: 'POST',
+    path: '/signin',
+    requestContext: {
+      identity: {
+        cognitoIdentityId: null,
+      }
+    }
+  };
+  return makeRequest(request)
+      .then(res => test.equal(res.statusCode, 500, "sign in without identity succeeded", res));
+});
+
+testPromise('catalog', test => {
+  let request = {
+    httpMethod: 'GET',
+    path: '/catalog',
+    "//body": null,
+    requestContext: {
+      identity: {
+        cognitoIdentityId: null,
+      }
+    }
+  };
+  return makeRequest(request)
+      .then(res => test.equal(res.statusCode, 200, "get catalog failed", res));
+});
+
+
+testPromise('subscriptions', test => {
+  let request = {
+    httpMethod: 'GET',
+    path: '/subscriptions',
+  };
+  return makeRequest(request)
+      .then(res => test.equal(res.statusCode, 200, "get subscriptions failed", res));
+});
+
+testPromise('subscriptions unsubscribe', () => {
+  let request = {
+    httpMethod: 'DELETE',
+    path: '/subscriptions/b04or5',
+  };
+  // do not test outcome, we aren't interested in the result.
+  return makeRequest(request);
+});
+
+testPromise('subscriptions subscribe', test => {
+  let request = {
+    httpMethod: 'PUT',
+    path: '/subscriptions/b04or5',
+  };
+  return makeRequest(request)
+      .then(res => test.equal(res.statusCode, 201, "create subscription failed", res));
+});
+
+testPromise('subscriptions usage', test => {
+  let request = {
+    httpMethod: 'GET',
+    path: '/subscriptions/b04or5/usage',
+    queryStringParameters: {
+      start: '2018-05-01',
+      end: '2018-05-31',
+    }
+  };
+  return makeRequest(request)
+      .then(res => test.equal(res.statusCode, 200, "get subscription usage failed", res));
+});
+
+
+testPromise('subscriptions unsubscribe', test => {
+  let request = {
+    httpMethod: 'DELETE',
+    path: '/subscriptions/b04or5',
+  };
+  return makeRequest(request)
+      .then(res => test.equal(res.statusCode, 200, "delete subscription failed", res));
+});
+
+testPromise('close server', () => Promise.resolve(server.close()));

--- a/lambdas/backend/yarn.lock
+++ b/lambdas/backend/yarn.lock
@@ -9,15 +9,112 @@ accepts@~1.3.5:
     mime-types "~2.1.18"
     negotiator "0.6.1"
 
+ajv@^5.1.0:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
+
+align-text@^0.1.1, align-text@^0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
+  dependencies:
+    kind-of "^3.0.2"
+    longest "^1.0.1"
+    repeat-string "^1.5.2"
+
+amdefine@>=0.0.4:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
+
+ansi-regex@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+
+ansi-styles@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+
+append-transform@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
+  dependencies:
+    default-require-extensions "^1.0.0"
+
+archy@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   dependencies:
     sprintf-js "~1.0.2"
 
+arr-diff@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
+  dependencies:
+    arr-flatten "^1.0.1"
+
+arr-diff@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
+
+arr-flatten@^1.0.1, arr-flatten@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+
+arr-union@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
+
+array-unique@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
+
+array-unique@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
+
+arrify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+
+asn1@~0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
+
+assert-plus@1.0.0, assert-plus@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
+
+assign-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
+
+async@^1.4.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+
+atob@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
 
 aws-sdk@^2.7.10:
   version "2.224.1"
@@ -34,13 +131,129 @@ aws-sdk@^2.7.10:
     xml2js "0.4.17"
     xmlbuilder "4.2.1"
 
-aws-serverless-express@^1.1.4:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/aws-serverless-express/-/aws-serverless-express-1.3.0.tgz#b7b52a30a5bccc7c77c8d24f2ccdbf948a138c6d"
+aws-serverless-express@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/aws-serverless-express/-/aws-serverless-express-3.2.0.tgz#f7ed4582ac59af3dda7f0e87e89e9e94c3ee67f1"
+  dependencies:
+    binary-case "^1.0.0"
+    type-is "^1.6.16"
+
+aws-sign2@~0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
+
+aws4@^1.6.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
+
+babel-code-frame@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
+  dependencies:
+    chalk "^1.1.3"
+    esutils "^2.0.2"
+    js-tokens "^3.0.2"
+
+babel-generator@^6.18.0:
+  version "6.26.1"
+  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
+  dependencies:
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    detect-indent "^4.0.0"
+    jsesc "^1.3.0"
+    lodash "^4.17.4"
+    source-map "^0.5.7"
+    trim-right "^1.0.1"
+
+babel-messages@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
+babel-template@^6.16.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    lodash "^4.17.4"
+
+babel-traverse@^6.18.0, babel-traverse@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    debug "^2.6.8"
+    globals "^9.18.0"
+    invariant "^2.2.2"
+    lodash "^4.17.4"
+
+babel-types@^6.18.0, babel-types@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
+  dependencies:
+    babel-runtime "^6.26.0"
+    esutils "^2.0.2"
+    lodash "^4.17.4"
+    to-fast-properties "^1.0.3"
+
+babylon@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
+
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
 base64-js@^1.0.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.3.tgz#fb13668233d9614cf5fb4bce95a9ba4096cdf801"
+
+base@^0.11.1:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
+  dependencies:
+    cache-base "^1.0.1"
+    class-utils "^0.3.5"
+    component-emitter "^1.2.1"
+    define-property "^1.0.0"
+    isobject "^3.0.1"
+    mixin-deep "^1.2.0"
+    pascalcase "^0.1.1"
+
+bcrypt-pbkdf@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
+  dependencies:
+    tweetnacl "^0.14.3"
+
+binary-case@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/binary-case/-/binary-case-1.1.4.tgz#d687104d59e38f2b9e658d3a58936963c59ab931"
+
+bind-obj-methods@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bind-obj-methods/-/bind-obj-methods-2.0.0.tgz#0178140dbe7b7bb67dc74892ace59bc0247f06f0"
+
+bluebird@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
 body-parser@1.18.2, body-parser@^1.15.2:
   version "1.18.2"
@@ -57,6 +270,52 @@ body-parser@1.18.2, body-parser@^1.15.2:
     raw-body "2.3.2"
     type-is "~1.6.15"
 
+boom@4.x.x:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/boom/-/boom-4.3.1.tgz#4f8a3005cb4a7e3889f749030fd25b96e01d2e31"
+  dependencies:
+    hoek "4.x.x"
+
+boom@5.x.x:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02"
+  dependencies:
+    hoek "4.x.x"
+
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
+braces@^1.8.2:
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-1.8.5.tgz#ba77962e12dff969d6b76711e914b737857bf6a7"
+  dependencies:
+    expand-range "^1.8.1"
+    preserve "^0.2.0"
+    repeat-element "^1.1.2"
+
+braces@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
+  dependencies:
+    arr-flatten "^1.1.0"
+    array-unique "^0.3.2"
+    extend-shallow "^2.0.1"
+    fill-range "^4.0.0"
+    isobject "^3.0.1"
+    repeat-element "^1.1.2"
+    snapdragon "^0.8.1"
+    snapdragon-node "^2.0.1"
+    split-string "^3.0.2"
+    to-regex "^3.0.1"
+
+buffer-from@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.0.0.tgz#4cb8832d23612589b0406e9e2956c17f06fdf531"
+
 buffer@4.9.1:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
@@ -65,12 +324,133 @@ buffer@4.9.1:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+builtin-modules@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
 
+cache-base@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
+  dependencies:
+    collection-visit "^1.0.0"
+    component-emitter "^1.2.1"
+    get-value "^2.0.6"
+    has-value "^1.0.0"
+    isobject "^3.0.1"
+    set-value "^2.0.0"
+    to-object-path "^0.3.0"
+    union-value "^1.0.0"
+    unset-value "^1.0.0"
+
+caching-transform@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/caching-transform/-/caching-transform-1.0.1.tgz#6dbdb2f20f8d8fbce79f3e94e9d1742dcdf5c0a1"
+  dependencies:
+    md5-hex "^1.2.0"
+    mkdirp "^0.5.1"
+    write-file-atomic "^1.1.4"
+
+camelcase@^1.0.2:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
+
+camelcase@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
+
+caseless@~0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+
+center-align@^0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/center-align/-/center-align-0.1.3.tgz#aa0d32629b6ee972200411cbd4461c907bc2b7ad"
+  dependencies:
+    align-text "^0.1.3"
+    lazy-cache "^1.0.3"
+
+chalk@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
+  dependencies:
+    ansi-styles "^2.2.1"
+    escape-string-regexp "^1.0.2"
+    has-ansi "^2.0.0"
+    strip-ansi "^3.0.0"
+    supports-color "^2.0.0"
+
+class-utils@^0.3.5:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
+  dependencies:
+    arr-union "^3.1.0"
+    define-property "^0.2.5"
+    isobject "^3.0.0"
+    static-extend "^0.1.1"
+
+clean-yaml-object@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz#63fb110dc2ce1a84dc21f6d9334876d010ae8b68"
+
+cliui@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
+  dependencies:
+    center-align "^0.1.1"
+    right-align "^0.1.1"
+    wordwrap "0.0.2"
+
+cliui@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
+    wrap-ansi "^2.0.0"
+
+co@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+
+code-point-at@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+collection-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
+  dependencies:
+    map-visit "^1.0.0"
+    object-visit "^1.0.0"
+
+color-support@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
+
+combined-stream@1.0.6, combined-stream@~1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
+  dependencies:
+    delayed-stream "~1.0.0"
+
 "common-lambda-assets@file:../_common":
   version "1.0.0"
+
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+
+component-emitter@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
+
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
 content-disposition@0.5.2:
   version "0.5.2"
@@ -80,6 +460,10 @@ content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
+convert-source-map@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
+
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
@@ -88,6 +472,18 @@ cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
 
+copy-descriptor@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
+
+core-js@^2.4.0:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.5.tgz#b14dde936c640c0579a6b50cabcc132dd6127e3b"
+
+core-util-is@1.0.2, core-util-is@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
 cors@^2.8.1:
   version "2.8.4"
   resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.4.tgz#2bd381f2eb201020105cd50ea59da63090694686"
@@ -95,11 +491,95 @@ cors@^2.8.1:
     object-assign "^4"
     vary "^1"
 
-debug@2.6.9:
+coveralls@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.1.tgz#12e15914eaa29204e56869a5ece7b9e1492d2ae2"
+  dependencies:
+    js-yaml "^3.6.1"
+    lcov-parse "^0.0.10"
+    log-driver "^1.2.5"
+    minimist "^1.2.0"
+    request "^2.79.0"
+
+cross-spawn@^4:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
+  dependencies:
+    lru-cache "^4.0.1"
+    which "^1.2.9"
+
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
+cryptiles@3.x.x:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe"
+  dependencies:
+    boom "5.x.x"
+
+dashdash@^1.12.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
+  dependencies:
+    assert-plus "^1.0.0"
+
+debug-log@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
+
+debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
+
+debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
+decamelize@^1.0.0, decamelize@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+
+default-require-extensions@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
+  dependencies:
+    strip-bom "^2.0.0"
+
+define-property@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
+  dependencies:
+    is-descriptor "^0.1.0"
+
+define-property@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-1.0.0.tgz#769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
+  dependencies:
+    is-descriptor "^1.0.0"
+
+define-property@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d"
+  dependencies:
+    is-descriptor "^1.0.2"
+    isobject "^3.0.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
 
 depd@1.1.1:
   version "1.1.1"
@@ -113,6 +593,22 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
 
+detect-indent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
+  dependencies:
+    repeating "^2.0.0"
+
+diff@^1.3.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
+
+ecc-jsbn@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
+  dependencies:
+    jsbn "~0.1.0"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -121,21 +617,75 @@ encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
 
+error-ex@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
+  dependencies:
+    is-arrayish "^0.2.1"
+
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.3:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
 esprima@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
 
+esutils@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+
 etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
 
+events-to-array@^1.0.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/events-to-array/-/events-to-array-1.1.2.tgz#2d41f563e1fe400ed4962fe1a4d5c6a7539df7f6"
+
 events@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+
+execa@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
+expand-brackets@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
+  dependencies:
+    is-posix-bracket "^0.1.0"
+
+expand-brackets@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
+  dependencies:
+    debug "^2.3.3"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    posix-character-classes "^0.1.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
+expand-range@^1.8.1:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
+  dependencies:
+    fill-range "^2.1.0"
 
 express@^4.14.0:
   version "4.16.3"
@@ -172,6 +722,81 @@ express@^4.14.0:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+extend-shallow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  dependencies:
+    is-extendable "^0.1.0"
+
+extend-shallow@^3.0.0, extend-shallow@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
+  dependencies:
+    assign-symbols "^1.0.0"
+    is-extendable "^1.0.1"
+
+extend@~3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
+
+extglob@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
+  dependencies:
+    is-extglob "^1.0.0"
+
+extglob@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
+  dependencies:
+    array-unique "^0.3.2"
+    define-property "^1.0.0"
+    expand-brackets "^2.1.4"
+    extend-shallow "^2.0.1"
+    fragment-cache "^0.2.1"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
+extsprintf@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
+
+extsprintf@^1.2.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
+
+fast-deep-equal@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+
+filename-regex@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
+
+fill-range@^2.1.0:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"
+  dependencies:
+    is-number "^2.1.0"
+    isobject "^2.0.0"
+    randomatic "^1.1.3"
+    repeat-element "^1.1.2"
+    repeat-string "^1.5.2"
+
+fill-range@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+    to-regex-range "^2.1.0"
+
 finalhandler@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.1.tgz#eebf4ed840079c83f4249038c9d703008301b105"
@@ -184,13 +809,206 @@ finalhandler@1.1.1:
     statuses "~1.4.0"
     unpipe "~1.0.0"
 
+find-cache-dir@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-0.1.1.tgz#c8defae57c8a52a8a784f9e31c57c742e993a0b9"
+  dependencies:
+    commondir "^1.0.1"
+    mkdirp "^0.5.1"
+    pkg-dir "^1.0.0"
+
+find-up@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
+  dependencies:
+    path-exists "^2.0.0"
+    pinkie-promise "^2.0.0"
+
+find-up@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  dependencies:
+    locate-path "^2.0.0"
+
+for-in@^1.0.1, for-in@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
+
+for-own@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
+  dependencies:
+    for-in "^1.0.1"
+
+foreground-child@^1.3.3, foreground-child@^1.5.3, foreground-child@^1.5.6:
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-1.5.6.tgz#4fd71ad2dfde96789b980a5c0a295937cb2f5ce9"
+  dependencies:
+    cross-spawn "^4"
+    signal-exit "^3.0.0"
+
+forever-agent@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
+
+form-data@~2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "1.0.6"
+    mime-types "^2.1.12"
+
 forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
 
+fragment-cache@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
+  dependencies:
+    map-cache "^0.2.2"
+
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
+
+fs-exists-cached@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz#cf25554ca050dc49ae6656b41de42258989dcbce"
+
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
+function-loop@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/function-loop/-/function-loop-1.0.1.tgz#8076bb305e8e6a3cceee2920765f330d190f340c"
+
+get-caller-file@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
+
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
+get-value@^2.0.3, get-value@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
+
+getpass@^0.1.1:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
+  dependencies:
+    assert-plus "^1.0.0"
+
+glob-base@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
+  dependencies:
+    glob-parent "^2.0.0"
+    is-glob "^2.0.0"
+
+glob-parent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-2.0.0.tgz#81383d72db054fcccf5336daa902f182f6edbb28"
+  dependencies:
+    is-glob "^2.0.0"
+
+glob@^7.0.0, glob@^7.0.5, glob@^7.0.6:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+globals@^9.18.0:
+  version "9.18.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
+
+graceful-fs@^4.1.11, graceful-fs@^4.1.2:
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
+handlebars@^4.0.3:
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.11.tgz#630a35dfe0294bc281edae6ffc5d329fc7982dcc"
+  dependencies:
+    async "^1.4.0"
+    optimist "^0.6.1"
+    source-map "^0.4.4"
+  optionalDependencies:
+    uglify-js "^2.6"
+
+har-schema@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
+
+har-validator@~5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
+  dependencies:
+    ajv "^5.1.0"
+    har-schema "^2.0.0"
+
+has-ansi@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
+  dependencies:
+    ansi-regex "^2.0.0"
+
+has-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+
+has-value@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
+  dependencies:
+    get-value "^2.0.3"
+    has-values "^0.1.4"
+    isobject "^2.0.0"
+
+has-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-1.0.0.tgz#18b281da585b1c5c51def24c930ed29a0be6b177"
+  dependencies:
+    get-value "^2.0.6"
+    has-values "^1.0.0"
+    isobject "^3.0.0"
+
+has-values@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-0.1.4.tgz#6d61de95d91dfca9b9a02089ad384bff8f62b771"
+
+has-values@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-1.0.0.tgz#95b0b63fec2146619a6fe57fe75628d5a39efe4f"
+  dependencies:
+    is-number "^3.0.0"
+    kind-of "^4.0.0"
+
+hawk@~6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
+  dependencies:
+    boom "4.x.x"
+    cryptiles "3.x.x"
+    hoek "4.x.x"
+    sntp "2.x.x"
+
+hoek@4.x.x:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
+
+hosted-git-info@^2.1.4:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.6.0.tgz#23235b29ab230c576aab0d4f13fc046b0b038222"
 
 http-errors@1.6.2:
   version "1.6.2"
@@ -210,6 +1028,14 @@ http-errors@~1.6.2:
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
 
+http-signature@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
+  dependencies:
+    assert-plus "^1.0.0"
+    jsprim "^1.2.2"
+    sshpk "^1.7.0"
+
 iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
@@ -222,50 +1048,475 @@ ieee754@^1.1.4:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.11.tgz#c16384ffe00f5b7835824e67b6f2bd44a5229455"
 
-inherits@2.0.3:
+imurmurhash@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2, inherits@2.0.3, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+
+invariant@^2.2.2:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  dependencies:
+    loose-envify "^1.0.0"
+
+invert-kv@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
 ipaddr.js@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.6.0.tgz#e3fa357b773da619f26e95f049d055c72796f86b"
 
-isarray@^1.0.0:
+is-accessor-descriptor@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-accessor-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz#169c2f6d3df1f992618072365c9b0ea1f6878656"
+  dependencies:
+    kind-of "^6.0.0"
+
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+
+is-buffer@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+
+is-builtin-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
+  dependencies:
+    builtin-modules "^1.0.0"
+
+is-data-descriptor@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-data-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
+  dependencies:
+    kind-of "^6.0.0"
+
+is-descriptor@^0.1.0:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
+  dependencies:
+    is-accessor-descriptor "^0.1.6"
+    is-data-descriptor "^0.1.4"
+    kind-of "^5.0.0"
+
+is-descriptor@^1.0.0, is-descriptor@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec"
+  dependencies:
+    is-accessor-descriptor "^1.0.0"
+    is-data-descriptor "^1.0.0"
+    kind-of "^6.0.2"
+
+is-dotfile@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
+
+is-equal-shallow@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz#2238098fc221de0bcfa5d9eac4c45d638aa1c534"
+  dependencies:
+    is-primitive "^2.0.0"
+
+is-extendable@^0.1.0, is-extendable@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+
+is-extendable@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
+  dependencies:
+    is-plain-object "^2.0.4"
+
+is-extglob@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
+
+is-finite@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
+  dependencies:
+    number-is-nan "^1.0.0"
+
+is-fullwidth-code-point@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
+  dependencies:
+    number-is-nan "^1.0.0"
+
+is-fullwidth-code-point@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+
+is-glob@^2.0.0, is-glob@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
+  dependencies:
+    is-extglob "^1.0.0"
+
+is-number@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-number@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-number@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
+
+is-odd@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-odd/-/is-odd-2.0.0.tgz#7646624671fd7ea558ccd9a2795182f2958f1b24"
+  dependencies:
+    is-number "^4.0.0"
+
+is-plain-obj@^1.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+
+is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  dependencies:
+    isobject "^3.0.1"
+
+is-posix-bracket@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
+
+is-primitive@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
+
+is-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+is-typedarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+
+is-utf8@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-windows@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+
+isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+
+isobject@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
+  dependencies:
+    isarray "1.0.0"
+
+isobject@^3.0.0, isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+
+isstream@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+
+istanbul-lib-coverage@^1.1.2, istanbul-lib-coverage@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz#f7d8f2e42b97e37fe796114cb0f9d68b5e3a4341"
+
+istanbul-lib-hook@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz#8538d970372cb3716d53e55523dd54b557a8d89b"
+  dependencies:
+    append-transform "^0.4.0"
+
+istanbul-lib-instrument@^1.10.0:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz#724b4b6caceba8692d3f1f9d0727e279c401af7b"
+  dependencies:
+    babel-generator "^6.18.0"
+    babel-template "^6.16.0"
+    babel-traverse "^6.18.0"
+    babel-types "^6.18.0"
+    babylon "^6.18.0"
+    istanbul-lib-coverage "^1.2.0"
+    semver "^5.3.0"
+
+istanbul-lib-report@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz#2df12188c0fa77990c0d2176d2d0ba3394188259"
+  dependencies:
+    istanbul-lib-coverage "^1.1.2"
+    mkdirp "^0.5.1"
+    path-parse "^1.0.5"
+    supports-color "^3.1.2"
+
+istanbul-lib-source-maps@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz#20fb54b14e14b3fb6edb6aca3571fd2143db44e6"
+  dependencies:
+    debug "^3.1.0"
+    istanbul-lib-coverage "^1.1.2"
+    mkdirp "^0.5.1"
+    rimraf "^2.6.1"
+    source-map "^0.5.3"
+
+istanbul-reports@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.4.0.tgz#3d7b44b912ecbe7652a603662b962120739646a1"
+  dependencies:
+    handlebars "^4.0.3"
 
 jmespath@0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
 
-js-yaml@^3.7.0:
+js-tokens@^3.0.0, js-tokens@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+
+js-yaml@^3.11.0, js-yaml@^3.2.7, js-yaml@^3.3.1, js-yaml@^3.6.1, js-yaml@^3.7.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+jsbn@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+
+jsesc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
+
+json-schema-traverse@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
+
+json-schema@0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
+
+json-stringify-safe@~5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+
+jsprim@^1.2.2:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
+  dependencies:
+    assert-plus "1.0.0"
+    extsprintf "1.3.0"
+    json-schema "0.2.3"
+    verror "1.10.0"
+
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
+  dependencies:
+    is-buffer "^1.1.5"
+
+kind-of@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
+  dependencies:
+    is-buffer "^1.1.5"
+
+kind-of@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
+
+kind-of@^6.0.0, kind-of@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
+
+lazy-cache@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
+
+lcid@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
+  dependencies:
+    invert-kv "^1.0.0"
+
+lcov-parse@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
+
+load-json-file@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+    strip-bom "^2.0.0"
+
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  dependencies:
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
+
 lodash@^4.0.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
+lodash@^4.17.4:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
+log-driver@^1.2.5:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.7.tgz#63b95021f0702fedfa2c9bb0a24e7797d71871d8"
+
+longest@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
+
+loose-envify@^1.0.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
+  dependencies:
+    js-tokens "^3.0.0"
+
+lru-cache@^4.0.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.2.tgz#45234b2e6e2f2b33da125624c4664929a0224c3f"
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
+map-cache@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
+
+map-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
+  dependencies:
+    object-visit "^1.0.0"
+
+md5-hex@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/md5-hex/-/md5-hex-1.3.0.tgz#d2c4afe983c4370662179b8cad145219135046c4"
+  dependencies:
+    md5-o-matic "^0.1.1"
+
+md5-o-matic@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/md5-o-matic/-/md5-o-matic-0.1.1.tgz#822bccd65e117c514fab176b25945d54100a03c3"
 
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
 
+mem@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
+  dependencies:
+    mimic-fn "^1.0.0"
+
 merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+
+merge-options@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-1.0.1.tgz#2a64b24457becd4e4dc608283247e94ce589aa32"
+  dependencies:
+    is-plain-obj "^1.1"
+
+merge-source-map@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646"
+  dependencies:
+    source-map "^0.6.1"
 
 methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
+micromatch@^2.3.11:
+  version "2.3.11"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
+  dependencies:
+    arr-diff "^2.0.0"
+    array-unique "^0.2.1"
+    braces "^1.8.2"
+    expand-brackets "^0.1.4"
+    extglob "^0.3.1"
+    filename-regex "^2.0.0"
+    is-extglob "^1.0.0"
+    is-glob "^2.0.1"
+    kind-of "^3.0.2"
+    normalize-path "^2.0.1"
+    object.omit "^2.0.0"
+    parse-glob "^3.0.4"
+    regex-cache "^0.4.2"
+
+micromatch@^3.1.8:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    braces "^2.3.1"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    extglob "^2.0.4"
+    fragment-cache "^0.2.1"
+    kind-of "^6.0.2"
+    nanomatch "^1.2.9"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.2"
+
 mime-db@~1.33.0:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
 
-mime-types@~2.1.18:
+mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.18:
   version "2.1.18"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
@@ -275,17 +1526,164 @@ mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
 
+mimic-fn@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
+
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimist@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+
+minimist@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+
+minimist@~0.0.1:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
+
+minipass@^2.2.0, minipass@^2.2.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.0.tgz#2e11b1c46df7fe7f1afbe9a490280add21ffe384"
+  dependencies:
+    safe-buffer "^5.1.1"
+    yallist "^3.0.0"
+
+mixin-deep@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
+  dependencies:
+    for-in "^1.0.2"
+    is-extendable "^1.0.1"
+
+mkdirp@^0.5.0, mkdirp@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  dependencies:
+    minimist "0.0.8"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+nanomatch@^1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.9.tgz#879f7150cb2dab7a471259066c104eee6e0fa7c2"
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    fragment-cache "^0.2.1"
+    is-odd "^2.0.0"
+    is-windows "^1.0.2"
+    kind-of "^6.0.2"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
-object-assign@^4:
+normalize-package-data@^2.3.2:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
+  dependencies:
+    hosted-git-info "^2.1.4"
+    is-builtin-module "^1.0.0"
+    semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
+
+normalize-path@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
+  dependencies:
+    remove-trailing-separator "^1.0.1"
+
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  dependencies:
+    path-key "^2.0.0"
+
+number-is-nan@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
+
+nyc@^11.6.0:
+  version "11.7.1"
+  resolved "https://registry.yarnpkg.com/nyc/-/nyc-11.7.1.tgz#7cb0a422e501b88ff2c1634341dec2560299d67b"
+  dependencies:
+    archy "^1.0.0"
+    arrify "^1.0.1"
+    caching-transform "^1.0.0"
+    convert-source-map "^1.5.1"
+    debug-log "^1.0.1"
+    default-require-extensions "^1.0.0"
+    find-cache-dir "^0.1.1"
+    find-up "^2.1.0"
+    foreground-child "^1.5.3"
+    glob "^7.0.6"
+    istanbul-lib-coverage "^1.1.2"
+    istanbul-lib-hook "^1.1.0"
+    istanbul-lib-instrument "^1.10.0"
+    istanbul-lib-report "^1.1.3"
+    istanbul-lib-source-maps "^1.2.3"
+    istanbul-reports "^1.4.0"
+    md5-hex "^1.2.0"
+    merge-source-map "^1.0.2"
+    micromatch "^2.3.11"
+    mkdirp "^0.5.0"
+    resolve-from "^2.0.0"
+    rimraf "^2.5.4"
+    signal-exit "^3.0.1"
+    spawn-wrap "^1.4.2"
+    test-exclude "^4.2.0"
+    yargs "11.1.0"
+    yargs-parser "^8.0.0"
+
+oauth-sign@~0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
+
+object-assign@^4, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+object-copy@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
+  dependencies:
+    copy-descriptor "^0.1.0"
+    define-property "^0.2.5"
+    kind-of "^3.0.3"
+
+object-visit@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
+  dependencies:
+    isobject "^3.0.0"
+
+object.omit@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
+  dependencies:
+    for-own "^0.1.4"
+    is-extendable "^0.1.1"
+
+object.pick@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
+  dependencies:
+    isobject "^3.0.1"
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -293,13 +1691,157 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  dependencies:
+    wrappy "1"
+
+opener@^1.4.1:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.4.3.tgz#5c6da2c5d7e5831e8ffa3964950f8d6674ac90b8"
+
+optimist@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
+  dependencies:
+    minimist "~0.0.1"
+    wordwrap "~0.0.2"
+
+os-homedir@^1.0.1, os-homedir@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
+
+os-locale@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz#42bc2900a6b5b8bd17376c8e882b65afccf24bf2"
+  dependencies:
+    execa "^0.7.0"
+    lcid "^1.0.0"
+    mem "^1.1.0"
+
+own-or-env@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/own-or-env/-/own-or-env-1.0.1.tgz#54ce601d3bf78236c5c65633aa1c8ec03f8007e4"
+  dependencies:
+    own-or "^1.0.0"
+
+own-or@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/own-or/-/own-or-1.0.0.tgz#4e877fbeda9a2ec8000fbc0bcae39645ee8bf8dc"
+
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+
+p-limit@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.2.0.tgz#0e92b6bedcb59f022c13d0f1949dc82d15909f1c"
+  dependencies:
+    p-try "^1.0.0"
+
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  dependencies:
+    p-limit "^1.1.0"
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+
+parse-glob@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"
+  dependencies:
+    glob-base "^0.3.0"
+    is-dotfile "^1.0.0"
+    is-extglob "^1.0.0"
+    is-glob "^2.0.0"
+
+parse-json@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
+  dependencies:
+    error-ex "^1.2.0"
+
 parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
 
+pascalcase@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
+
+path-exists@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
+  dependencies:
+    pinkie-promise "^2.0.0"
+
+path-exists@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+
+path-key@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+
+path-parse@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+
+path-type@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
+  dependencies:
+    graceful-fs "^4.1.2"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+
+performance-now@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+
+pify@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+
+pinkie-promise@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
+  dependencies:
+    pinkie "^2.0.0"
+
+pinkie@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+
+pkg-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
+  dependencies:
+    find-up "^1.0.0"
+
+posix-character-classes@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
+
+preserve@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
+
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
 proxy-addr@~2.0.3:
   version "2.0.3"
@@ -308,17 +1850,36 @@ proxy-addr@~2.0.3:
     forwarded "~0.1.2"
     ipaddr.js "1.6.0"
 
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+
 punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+
+punycode@^1.3.2, punycode@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
 qs@6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
+qs@~6.5.1:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+
 querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+
+randomatic@^1.1.3:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
+  dependencies:
+    is-number "^3.0.0"
+    kind-of "^4.0.0"
 
 range-parser@~1.2.0:
   version "1.2.0"
@@ -333,9 +1894,140 @@ raw-body@2.3.2:
     iconv-lite "0.4.19"
     unpipe "1.0.0"
 
+read-pkg-up@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
+  dependencies:
+    find-up "^1.0.0"
+    read-pkg "^1.0.0"
+
+read-pkg@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
+  dependencies:
+    load-json-file "^1.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^1.0.0"
+
+readable-stream@^2, readable-stream@^2.1.5:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
+regenerator-runtime@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+
+regex-cache@^0.4.2:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd"
+  dependencies:
+    is-equal-shallow "^0.1.3"
+
+regex-not@^1.0.0, regex-not@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
+  dependencies:
+    extend-shallow "^3.0.2"
+    safe-regex "^1.1.0"
+
+remove-trailing-separator@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
+
+repeat-element@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
+
+repeat-string@^1.5.2, repeat-string@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
+
+repeating@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
+  dependencies:
+    is-finite "^1.0.0"
+
+request@^2.79.0:
+  version "2.85.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.85.0.tgz#5a03615a47c61420b3eb99b7dba204f83603e1fa"
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.6.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.1"
+    forever-agent "~0.6.1"
+    form-data "~2.3.1"
+    har-validator "~5.0.3"
+    hawk "~6.0.2"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.17"
+    oauth-sign "~0.8.2"
+    performance-now "^2.1.0"
+    qs "~6.5.1"
+    safe-buffer "^5.1.1"
+    stringstream "~0.0.5"
+    tough-cookie "~2.3.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.1.0"
+
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+
+require-main-filename@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
+
+resolve-from@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
+
+resolve-url@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
+
+ret@~0.1.10:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
+
+right-align@^0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
+  dependencies:
+    align-text "^0.1.1"
+
+rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
+  dependencies:
+    glob "^7.0.5"
+
 safe-buffer@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+
+safe-regex@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
+  dependencies:
+    ret "~0.1.10"
 
 sax@1.2.1:
   version "1.2.1"
@@ -344,6 +2036,10 @@ sax@1.2.1:
 sax@>=0.6.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+
+"semver@2 || 3 || 4 || 5", semver@^5.3.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
 send@0.16.2:
   version "0.16.2"
@@ -372,6 +2068,28 @@ serve-static@1.13.2:
     parseurl "~1.3.2"
     send "0.16.2"
 
+set-blocking@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+
+set-value@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.1"
+    to-object-path "^0.3.0"
+
+set-value@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.3"
+    split-string "^3.0.1"
+
 setprototypeof@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
@@ -380,9 +2098,159 @@ setprototypeof@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
 
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
+signal-exit@^3.0.0, signal-exit@^3.0.1, signal-exit@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+slide@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
+
+snapdragon-node@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
+  dependencies:
+    define-property "^1.0.0"
+    isobject "^3.0.0"
+    snapdragon-util "^3.0.1"
+
+snapdragon-util@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz#f956479486f2acd79700693f6f7b805e45ab56e2"
+  dependencies:
+    kind-of "^3.2.0"
+
+snapdragon@^0.8.1:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/snapdragon/-/snapdragon-0.8.2.tgz#64922e7c565b0e14204ba1aa7d6964278d25182d"
+  dependencies:
+    base "^0.11.1"
+    debug "^2.2.0"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    map-cache "^0.2.2"
+    source-map "^0.5.6"
+    source-map-resolve "^0.5.0"
+    use "^3.1.0"
+
+sntp@2.x.x:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.1.0.tgz#2c6cec14fedc2222739caf9b5c3d85d1cc5a2cc8"
+  dependencies:
+    hoek "4.x.x"
+
+source-map-resolve@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.1.tgz#7ad0f593f2281598e854df80f19aae4b92d7a11a"
+  dependencies:
+    atob "^2.0.0"
+    decode-uri-component "^0.2.0"
+    resolve-url "^0.2.1"
+    source-map-url "^0.4.0"
+    urix "^0.1.0"
+
+source-map-support@^0.5.4:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.5.tgz#0d4af9e00493e855402e8ec36ebed2d266fceb90"
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map-url@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
+
+source-map@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
+  dependencies:
+    amdefine ">=0.0.4"
+
+source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
+source-map@^0.6.0, source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
+spawn-wrap@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/spawn-wrap/-/spawn-wrap-1.4.2.tgz#cff58e73a8224617b6561abdc32586ea0c82248c"
+  dependencies:
+    foreground-child "^1.5.6"
+    mkdirp "^0.5.0"
+    os-homedir "^1.0.1"
+    rimraf "^2.6.2"
+    signal-exit "^3.0.2"
+    which "^1.3.0"
+
+spdx-correct@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.0.tgz#05a5b4d7153a195bc92c3c425b69f3b2a9524c82"
+  dependencies:
+    spdx-expression-parse "^3.0.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-exceptions@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz#2c7ae61056c714a5b9b9b2b2af7d311ef5c78fe9"
+
+spdx-expression-parse@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-license-ids@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz#7a7cd28470cc6d3a1cfe6d66886f6bc430d3ac87"
+
+split-string@^3.0.1, split-string@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
+  dependencies:
+    extend-shallow "^3.0.0"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+
+sshpk@^1.7.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.14.1.tgz#130f5975eddad963f1d56f92b9ac6c51fa9f83eb"
+  dependencies:
+    asn1 "~0.2.3"
+    assert-plus "^1.0.0"
+    dashdash "^1.12.0"
+    getpass "^0.1.1"
+  optionalDependencies:
+    bcrypt-pbkdf "^1.0.0"
+    ecc-jsbn "~0.1.1"
+    jsbn "~0.1.0"
+    tweetnacl "~0.14.0"
+
+stack-utils@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
+
+static-extend@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
+  dependencies:
+    define-property "^0.2.5"
+    object-copy "^0.1.0"
 
 "statuses@>= 1.3.1 < 2", "statuses@>= 1.4.0 < 2":
   version "1.5.0"
@@ -392,16 +2260,247 @@ statuses@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
 
-type-is@~1.6.15, type-is@~1.6.16:
+string-width@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
+  dependencies:
+    code-point-at "^1.0.0"
+    is-fullwidth-code-point "^1.0.0"
+    strip-ansi "^3.0.0"
+
+string-width@^2.0.0, string-width@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^4.0.0"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  dependencies:
+    safe-buffer "~5.1.0"
+
+stringstream@~0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
+
+strip-ansi@^3.0.0, strip-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+  dependencies:
+    ansi-regex "^2.0.0"
+
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  dependencies:
+    ansi-regex "^3.0.0"
+
+strip-bom@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
+  dependencies:
+    is-utf8 "^0.2.0"
+
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+
+supports-color@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+
+supports-color@^3.1.2:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
+  dependencies:
+    has-flag "^1.0.0"
+
+tap-mocha-reporter@^3.0.7:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/tap-mocha-reporter/-/tap-mocha-reporter-3.0.7.tgz#235e57893b500861ea5d0924965dadfb2f05eaa7"
+  dependencies:
+    color-support "^1.1.0"
+    debug "^2.1.3"
+    diff "^1.3.2"
+    escape-string-regexp "^1.0.3"
+    glob "^7.0.5"
+    js-yaml "^3.3.1"
+    tap-parser "^5.1.0"
+    unicode-length "^1.0.0"
+  optionalDependencies:
+    readable-stream "^2.1.5"
+
+tap-parser@^5.1.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/tap-parser/-/tap-parser-5.4.0.tgz#6907e89725d7b7fa6ae41ee2c464c3db43188aec"
+  dependencies:
+    events-to-array "^1.0.1"
+    js-yaml "^3.2.7"
+  optionalDependencies:
+    readable-stream "^2"
+
+tap-parser@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/tap-parser/-/tap-parser-7.0.0.tgz#54db35302fda2c2ccc21954ad3be22b2cba42721"
+  dependencies:
+    events-to-array "^1.0.1"
+    js-yaml "^3.2.7"
+    minipass "^2.2.0"
+
+tap@^11.1.4:
+  version "11.1.4"
+  resolved "https://registry.yarnpkg.com/tap/-/tap-11.1.4.tgz#bea90823ad86d8564e0a35dc2ef9e917bd5f153e"
+  dependencies:
+    bind-obj-methods "^2.0.0"
+    bluebird "^3.5.1"
+    clean-yaml-object "^0.1.0"
+    color-support "^1.1.0"
+    coveralls "^3.0.0"
+    foreground-child "^1.3.3"
+    fs-exists-cached "^1.0.0"
+    function-loop "^1.0.1"
+    glob "^7.0.0"
+    isexe "^2.0.0"
+    js-yaml "^3.11.0"
+    minipass "^2.2.1"
+    mkdirp "^0.5.1"
+    nyc "^11.6.0"
+    opener "^1.4.1"
+    os-homedir "^1.0.2"
+    own-or "^1.0.0"
+    own-or-env "^1.0.1"
+    rimraf "^2.6.2"
+    signal-exit "^3.0.0"
+    source-map-support "^0.5.4"
+    stack-utils "^1.0.0"
+    tap-mocha-reporter "^3.0.7"
+    tap-parser "^7.0.0"
+    tmatch "^3.1.0"
+    trivial-deferred "^1.0.1"
+    tsame "^1.1.2"
+    write-file-atomic "^2.3.0"
+    yapool "^1.0.0"
+
+test-exclude@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.1.tgz#dfa222f03480bca69207ca728b37d74b45f724fa"
+  dependencies:
+    arrify "^1.0.1"
+    micromatch "^3.1.8"
+    object-assign "^4.1.0"
+    read-pkg-up "^1.0.1"
+    require-main-filename "^1.0.1"
+
+tmatch@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/tmatch/-/tmatch-3.1.0.tgz#701264fd7582d0144a80c85af3358cca269c71e3"
+
+to-fast-properties@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+to-object-path@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
+  dependencies:
+    kind-of "^3.0.2"
+
+to-regex-range@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-2.1.1.tgz#7c80c17b9dfebe599e27367e0d4dd5590141db38"
+  dependencies:
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+
+to-regex@^3.0.1, to-regex@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
+  dependencies:
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    regex-not "^1.0.2"
+    safe-regex "^1.1.0"
+
+tough-cookie@~2.3.3:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
+  dependencies:
+    punycode "^1.4.1"
+
+trim-right@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+
+trivial-deferred@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/trivial-deferred/-/trivial-deferred-1.0.1.tgz#376d4d29d951d6368a6f7a0ae85c2f4d5e0658f3"
+
+tsame@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/tsame/-/tsame-1.1.2.tgz#5ce0002acf685942789c63018797a2aa5e6b03c5"
+
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  dependencies:
+    safe-buffer "^5.0.1"
+
+tweetnacl@^0.14.3, tweetnacl@~0.14.0:
+  version "0.14.5"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+
+type-is@^1.6.16, type-is@~1.6.15, type-is@~1.6.16:
   version "1.6.16"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194"
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.18"
 
+uglify-js@^2.6:
+  version "2.8.29"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
+  dependencies:
+    source-map "~0.5.1"
+    yargs "~3.10.0"
+  optionalDependencies:
+    uglify-to-browserify "~1.0.0"
+
+uglify-to-browserify@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
+
+unicode-length@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/unicode-length/-/unicode-length-1.0.3.tgz#5ada7a7fed51841a418a328cf149478ac8358abb"
+  dependencies:
+    punycode "^1.3.2"
+    strip-ansi "^3.0.1"
+
+union-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
+  dependencies:
+    arr-union "^3.1.0"
+    get-value "^2.0.6"
+    is-extendable "^0.1.1"
+    set-value "^0.4.3"
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+
+unset-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
+  dependencies:
+    has-value "^0.3.1"
+    isobject "^3.0.0"
+
+urix@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
 
 url@0.10.3:
   version "0.10.3"
@@ -409,6 +2508,16 @@ url@0.10.3:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/use/-/use-3.1.0.tgz#14716bf03fdfefd03040aef58d8b4b85f3a7c544"
+  dependencies:
+    kind-of "^6.0.2"
+
+util-deprecate@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
 utils-merge@1.0.1:
   version "1.0.1"
@@ -418,9 +2527,77 @@ uuid@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
+uuid@^3.1.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
+
+validate-npm-package-license@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz#81643bcbef1bdfecd4623793dc4648948ba98338"
+  dependencies:
+    spdx-correct "^3.0.0"
+    spdx-expression-parse "^3.0.0"
+
 vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
+
+verror@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
+  dependencies:
+    assert-plus "^1.0.0"
+    core-util-is "1.0.2"
+    extsprintf "^1.2.0"
+
+which-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
+
+which@^1.2.9, which@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+  dependencies:
+    isexe "^2.0.0"
+
+window-size@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
+
+wordwrap@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
+
+wordwrap@~0.0.2:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
+
+wrap-ansi@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
+  dependencies:
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+write-file-atomic@^1.1.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-1.3.4.tgz#f807a4f0b1d9e913ae7a48112e6cc3af1991b45f"
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    slide "^1.1.5"
+
+write-file-atomic@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab"
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
 
 xml2js@0.4.17:
   version "0.4.17"
@@ -434,3 +2611,57 @@ xmlbuilder@4.2.1, xmlbuilder@^4.1.0:
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-4.2.1.tgz#aa58a3041a066f90eaa16c2f5389ff19f3f461a5"
   dependencies:
     lodash "^4.0.0"
+
+y18n@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+
+yallist@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
+
+yapool@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/yapool/-/yapool-1.0.0.tgz#f693f29a315b50d9a9da2646a7a6645c96985b6a"
+
+yargs-parser@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs@11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
+
+yargs@~3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.10.0.tgz#f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1"
+  dependencies:
+    camelcase "^1.0.2"
+    cliui "^2.1.0"
+    decamelize "^1.0.0"
+    window-size "0.1.0"

--- a/lambdas/listener/index.js
+++ b/lambdas/listener/index.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 The Hyve B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 'use strict';
 const controller = require('common-lambda-assets/customers-controller.js');
 
@@ -32,8 +48,8 @@ exports.handler = (event, context, callback) => {
     }
 };
 
-function subscribe(customerId, productCode, callback) {
-    console.log(`Subscribing customer ${customerId} to product code ${productCode}`);
+function subscribe(marketplaceCustomerId, productCode, callback) {
+    console.log(`Subscribing customer ${marketplaceCustomerId} to product code ${productCode}`);
 
     function err(err)  {
         console.log("error: " + err);
@@ -41,15 +57,15 @@ function subscribe(customerId, productCode, callback) {
     }
 
     // get identity id for marketplace customer id
-    controller.getCognitoIdentityId(customerId, err, identityId => {
-        console.log("Got cognito identity : " + identityId);
+    controller.getIdentityFromMarketplaceId(marketplaceCustomerId, err, identity => {
+      console.log(`Got cognito identity ${identity.cognitoIdentityId}`);
 
-        controller.getUsagePlanForProductCode(productCode, err, usagePlan => {
-            controller.subscribe(identityId, usagePlan.id, err, result => {
-                callback(null, result)
-            })
-        })
-    })
+      controller.getUsagePlanForProductCode(productCode, err, usagePlan => {
+        controller.subscribe(identity, usagePlan.id, err, result => {
+            callback(null, result);
+        });
+      });
+    });
 }
 
 function unsubscribe(customerId, productCode, callback) {
@@ -61,13 +77,13 @@ function unsubscribe(customerId, productCode, callback) {
     }
 
     // get identity id for marketplace customer id
-    controller.getCognitoIdentityId(customerId, err, identityId => {
-        console.log("Got cognito identity : " + identityId);
+    controller.getIdentityFromMarketplaceId(customerId, err, identity => {
+      console.log(`Got cognito identity ${identity.cognitoIdentityId}`);
 
-        controller.getUsagePlanForProductCode(productCode, err, usagePlan => {
-            controller.unsubscribe(identityId, usagePlan.id, err, result => {
-                callback(null, result)
-            })
+      controller.getUsagePlanForProductCode(productCode, err, usagePlan => {
+        controller.unsubscribe(identity, usagePlan.id, err, result => {
+          callback(null, result)
         })
+      })
     })
 }


### PR DESCRIPTION
Update API key name based on user attributes, and refactored backend code to always store state in DynamoDB. This way the link between the user and the API key ID is always persisted and doesn't rely on the API key name.

Other changes:
- spacing is made more consistent with the rest of the code.
- documented all customer-controller backend functions
- created integration tests